### PR TITLE
Update to Kokkos 4.4.1 via parthenon

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Background
+
+## Description of Changes
+
+- [ ]
+
+## Checklist
+
+- [ ] New features are documented
+- [ ] Tests added for bug fixes and new features
+- [ ] (@lanl.gov employees) Update copyright on changed files
+

--- a/env/bash
+++ b/env/bash
@@ -27,9 +27,9 @@ if [[ $HOSTNAME == ch-fe* ]]; then
     elif [[ $SLURM_JOB_PARTITION == debug ]]; then
         PARTITION="chicoma-cpu"
     fi
-elif [[ "$HOSTNAME" =~ ^ve-rfe[1-3]$ || ( $SLURM_CLUSTER_NAME == "venado" && $SLURM_JOB_PARTITION == "gpu" ) ]]; then
+elif [[ "$HOSTNAME" =~ ^ve-rfe[1-3]$ || "$HOSTNAME" =~ ^ve-fe[1-3]$ || ( $SLURM_CLUSTER_NAME == "venado" && $SLURM_JOB_PARTITION == "gpu" ) ]]; then
     PARTITION="venado-gh"
-elif [[ "$HOSTNAME" =~ ^ve-rfe[4-7]$ || ( $SLURM_CLUSTER_NAME == "venado" && $SLURM_JOB_PARTITION == "cpu" ) ]]; then
+elif [[ "$HOSTNAME" =~ ^ve-rfe[4-7]$ || "$HOSTNAME" =~ ^ve-fe[4-7]$ || ( $SLURM_CLUSTER_NAME == "venado" && $SLURM_JOB_PARTITION == "cpu" ) ]]; then
     PARTITION="venado-gg"
 else # Catch-all for Darwin
     if [ -z "$SLURM_JOB_PARTITION" ]; then
@@ -125,8 +125,12 @@ elif [[ $PARTITION == "darwin-a100" ]]; then
     module list
     echo "...setup SUCCEEDED"
 elif [[ $PARTITION == "venado-gh" ]]; then
-    module load PrgEnv-gnu
-    module load cray-mpich cray-hdf5-parallel cudatoolkit
+module load PrgEnv-gnu
+    module load cray-mpich
+    #module load cray-hdf5-parallel # Compiler wrappers fail to find hdf5.h 2024/11/8
+    export HDF5_ROOT=/opt/cray/pe/hdf5-parallel/1.14.3.1/gnu/12.3
+    module load cudatoolkit
+    module load cmake
     export MPICH_OFI_NIC_POLICY=GPU   # GPU NUMA ROUND-ROBIN
     export MPICH_GPU_SUPPORT_ENABLED=1 # Allows GPU Aware MPI
     export CRAY_ACCEL_TARGET=nvidia90
@@ -135,6 +139,7 @@ elif [[ $PARTITION == "venado-gh" ]]; then
     export MPICH_MAX_THREAD_SAFETY=multiple
     export FI_CXI_RX_MATCH_MODE=hybrid
     export PMI_MMAP_SYNC_WAIT_TIME=600
+    export NVCC_WRAPPER_DEFAULT_COMPILER=g++
     module list
     echo "...setup SUCCEEDED"
 elif [[ $PARTITION == "venado-gg" ]]; then
@@ -149,10 +154,12 @@ elif [[ $PARTITION == "venado-gg" ]]; then
     echo "...setup SUCCEEDED"
 fi
 
-echo ""
-echo "To configure and build the code, you can use the function (-h flag for options)"
-echo "  build_jaybenne"
-echo ""
+if [[ $PARTITION != "unknown" ]]; then
+    echo ""
+    echo "To configure and build the code, you can use the function (-h flag for options)"
+    echo "  build_jaybenne"
+    echo ""
+fi
 
 function build_jaybenne {
 
@@ -237,7 +244,16 @@ function build_jaybenne {
                   ${JOVIAN_ENV_DIR}/../
         elif [[ $PARTITION == "chicoma-gpu" ]]; then
             cmake -DJAYBENNE_ENABLE_CUDA=On \
-                  -DKokkos_ARCH_VOLTA70=On \
+                  -DKokkos_ARCH_AMPERE80=On \
+                  -DCMAKE_CXX_COMPILER=${JOVIAN_ENV_DIR}/../external/parthenon/external/Kokkos/bin/nvcc_wrapper \
+                  $CMAKE_FLAGS \
+                  ${JOVIAN_ENV_DIR}/../
+        elif [[ $PARTITION == "venado-gg" ]]; then
+            cmake $CMAKE_FLAGS \
+                  ${JOVIAN_ENV_DIR}/../
+        elif [[ $PARTITION == "venado-gh" ]]; then
+            cmake -DJAYBENNE_ENABLE_CUDA=On \
+                  -DKokkos_ARCH_HOPPER900=On \
                   -DCMAKE_CXX_COMPILER=${JOVIAN_ENV_DIR}/../external/parthenon/external/Kokkos/bin/nvcc_wrapper \
                   $CMAKE_FLAGS \
                   ${JOVIAN_ENV_DIR}/../

--- a/env/bash
+++ b/env/bash
@@ -125,7 +125,7 @@ elif [[ $PARTITION == "darwin-a100" ]]; then
     module list
     echo "...setup SUCCEEDED"
 elif [[ $PARTITION == "venado-gh" ]]; then
-module load PrgEnv-gnu
+    module load PrgEnv-gnu
     module load cray-mpich
     #module load cray-hdf5-parallel # Compiler wrappers fail to find hdf5.h 2024/11/8
     export HDF5_ROOT=/opt/cray/pe/hdf5-parallel/1.14.3.1/gnu/12.3


### PR DESCRIPTION
## Background

Parthenon moved to Kokkos 4.4.1 and we want to as well, especially because it seems to be more stable on Chicoma/Venado GPU partitions

## Description of Changes

- [x] Switch our Parthenon submodule to the current branch that includes Kokkos 4.4.1 support.
- [x] Update `env/bash` to (sort of) support Venado
- [x] Add PR template

## Checklist

- [x] New features are documented
- [x] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files
- [x] [Parthenon PR](https://github.com/parthenon-hpc-lab/parthenon/pull/1191) is merged