### PR TITLE
Add profiling around one timestep

### DIFF
--- a/inputs/inf.in
+++ b/inputs/inf.in
@@ -52,16 +52,16 @@ numin = 1.e10
 numax = 1.e20
 do_emission = true
 do_feedback = false
-opacity_model = constant
-opacity_constant_value = 1.0 # cm^2/g
-scattering_model = constant
-scattering_constant_value = 1.0e5
 transport_model = zone_size
 tracking_algo = history # event
 source_strategy = uniform
 seed = 349857
 
 <mcblock>
+opacity_model = constant
+opacity_constant_value = 1.0 # cm^2/g
+scattering_model = constant
+scattering_constant_value = 1.0e5
 specific_heat = 1.0e8 # erg/K/g
 initial_density = 1.0 # g cm^-3
 initial_temperature = 1.0 # keV

--- a/inputs/inf_stiff.in
+++ b/inputs/inf_stiff.in
@@ -47,16 +47,16 @@ numin = 1.e10
 numax = 1.e20
 do_emission = true
 do_feedback = false
-opacity_model = constant
-opacity_constant_value = 1000.0 # cm^2/g
-scattering_model = constant
-scattering_constant_value = 0.0 #1.0e5
 transport_model = zone_size
 tracking_algo = history # event
 source_strategy = uniform
 seed = 349856
 
 <mcblock>
+opacity_model = constant
+opacity_constant_value = 1000.0 # cm^2/g
+scattering_model = constant
+scattering_constant_value = 0.0 #1.0e5
 specific_heat = 1.0e7 # erg/K/g
 initial_density = 1.0 # g cm^-3
 initial_temperature = 1.0 # keV

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -260,6 +260,8 @@ TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt) {
   namespace fj = field::jaybenne;
   namespace fjh = field::jaybenne::host;
 
+  Kokkos::Profiling::pushRegion("Jaybenne::Timestep");
+
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
   auto &jbn = pm->packages.Get("jaybenne");
@@ -572,6 +574,8 @@ TaskStatus UpdateFluid(MeshData<Real> *md) {
         const Real delta = vmesh(b, fj::energy_delta(), k, j, i) / dv;
         ee += delta;
       });
+
+  Kokkos::Profiling::popRegion(); // End of Jaybenne timestep
 
   return TaskStatus::complete;
 }

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -77,6 +77,9 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
   auto &ddmc_reg =
       pmesh->mesh_data.AddShallow("ddmc_reg", pmesh->mesh_data.Get(), ddmc_field_names);
 
+  TaskCollection tc;
+  TaskID none(0);
+
   auto &timing_region0 = tc.AddRegion(1);
   {
     auto &tl = timing_region0[0];
@@ -86,8 +89,6 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
     });
   }
 
-  TaskCollection tc;
-  TaskID none(0);
   const int num_partitions = pmesh->DefaultNumPartitions();
   PARTHENON_REQUIRE(
       num_partitions == 1,
@@ -110,17 +111,24 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
 
     // keep pushing particles until there are none left
     auto [itl, push] = tl.AddSublist(bcs, {1, max_transport_iterations});
+    auto time_start = itl.AddTask(none, []() {
+      Kokkos::Profiling::pushRegion("Jaybenne::TransportLoop");
+      return TaskStatus::complete;
+    });
     auto transport =
-        use_ddmc ? itl.AddTask(none, TransportPhotons_DDMC, base.get(), t_start, dt)
-                 : itl.AddTask(none, TransportPhotons, base.get(), t_start, dt);
+        use_ddmc ? itl.AddTask(time_start, TransportPhotons_DDMC, base.get(), t_start, dt)
+                 : itl.AddTask(time_start, TransportPhotons, base.get(), t_start, dt);
     auto reset_comms = itl.AddTask(transport, MeshResetCommunication, base.get());
     auto send = itl.AddTask(reset_comms, MeshSend, base.get());
     auto receive = itl.AddTask(transport | send, MeshReceive, base.get());
     auto sample_ddmc_bface =
         use_ddmc ? itl.AddTask(receive, SampleDDMCBlockFace, base.get()) : receive;
-    auto complete =
-        itl.AddTask(TQ::once_per_region | TQ::global_sync | TQ::completion,
-                    sample_ddmc_bface, CheckCompletion, base.get(), t_start + dt);
+    auto time_stop = itl.AddTask(sample_ddmc_bface, []() {
+      Kokkos::Profiling::popRegion(/*Jaybenne::TransportLoop*/);
+      return TaskStatus::complete;
+    });
+    auto complete = itl.AddTask(TQ::once_per_region | TQ::global_sync | TQ::completion,
+                                time_stop, CheckCompletion, base.get(), t_start + dt);
 
     // Update radiation fields
     auto eval_rad =


### PR DESCRIPTION
## Background

We want to be able to cleanly see one Jaybenne timestep in profiling tools

## Description of Changes

- [x] Add `Kokkos::Profiling::pushRegion("Jaybenne::Timestep"); at start of first task in Jaybenne timestep
- [x] Add `Kokkos::Profiling::popRegion();` at end of last task in Jaybenne timestep

Note that, because both these tasks are inside loops over partitions, this may not work (I'm not sure) if we have more than one partition. But right now we require one partition anyway so that's not an immediate issue.

## Checklist

- [ ] New features are documented
- [x] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files

