### PR TITLE
Add rudimentary particle population control.

### DIFF
--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -160,6 +160,9 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
 
     // Update fluid fields
     auto update_fluid = tl.AddTask(eval_rad, jaybenne::UpdateFluid, base.get());
+
+    // Control particle population
+    auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get());
   }
 
   auto &timing_region1 = tc.AddRegion(1);
@@ -268,6 +271,10 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   pkg->AddField(field::jaybenne::source_ew_per_cell::name(), m_onecopy);
   pkg->AddField(field::jaybenne::source_num_per_cell::name(), m_onecopy);
   pkg->AddField(field::jaybenne::energy_delta::name(), m_onecopy);
+
+  // Population control fields
+  pkg->AddField(field::jaybenne::active_ew_per_cell::name(), m_onecopy);
+  pkg->AddField(field::jaybenne::active_num_per_cell::name(), m_onecopy);
 
   // Face-based radiation fields
   Metadata mface({Metadata::Face, Metadata::Derived, Metadata::FillGhost});

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -275,6 +275,7 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   // Population control fields
   pkg->AddField(field::jaybenne::active_ew_per_cell::name(), m_onecopy);
   pkg->AddField(field::jaybenne::active_num_per_cell::name(), m_onecopy);
+  pkg->AddField(field::jaybenne::old_active_ew_per_cell::name(), m_onecopy);
 
   // Face-based radiation fields
   Metadata mface({Metadata::Face, Metadata::Derived, Metadata::FillGhost});

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -270,6 +270,7 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   Metadata m_onecopy({Metadata::Cell, Metadata::OneCopy});
   pkg->AddField(field::jaybenne::source_ew_per_cell::name(), m_onecopy);
   pkg->AddField(field::jaybenne::source_num_per_cell::name(), m_onecopy);
+  pkg->AddField(field::jaybenne::delta_num_per_cell::name(), m_onecopy);
   pkg->AddField(field::jaybenne::energy_delta::name(), m_onecopy);
 
   // Population control fields

--- a/src/jaybenne/jaybenne.hpp
+++ b/src/jaybenne/jaybenne.hpp
@@ -85,6 +85,7 @@ TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt);
 template <typename T>
 TaskStatus EvaluateRadiationEnergy(T *md);
 TaskStatus UpdateFluid(MeshData<Real> *md);
+TaskStatus ControlPopulation(MeshData<Real> *md);
 
 // TaskCollection for radiation step
 TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt);

--- a/src/jaybenne/jaybenne.hpp
+++ b/src/jaybenne/jaybenne.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/jaybenne/jaybenne_variables.hpp
+++ b/src/jaybenne/jaybenne_variables.hpp
@@ -39,6 +39,8 @@ JAYBENNE_FIELD_VARIABLE(field.jaybenne, source_ew_per_cell);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, source_num_per_cell);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, emission_cdf);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, energy_delta);
+JAYBENNE_FIELD_VARIABLE(field.jaybenne, active_ew_per_cell);
+JAYBENNE_FIELD_VARIABLE(field.jaybenne, active_num_per_cell);
 namespace host {
 typedef HOST_DENSITY density;
 typedef HOST_SPECIFIC_INTERNAL_ENERGY sie;

--- a/src/jaybenne/jaybenne_variables.hpp
+++ b/src/jaybenne/jaybenne_variables.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/jaybenne/jaybenne_variables.hpp
+++ b/src/jaybenne/jaybenne_variables.hpp
@@ -37,6 +37,7 @@ JAYBENNE_FIELD_VARIABLE(field.jaybenne, fleck_factor);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, ddmc_face_prob);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, source_ew_per_cell);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, source_num_per_cell);
+JAYBENNE_FIELD_VARIABLE(field.jaybenne, delta_num_per_cell);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, emission_cdf);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, energy_delta);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, active_ew_per_cell);

--- a/src/jaybenne/jaybenne_variables.hpp
+++ b/src/jaybenne/jaybenne_variables.hpp
@@ -41,6 +41,7 @@ JAYBENNE_FIELD_VARIABLE(field.jaybenne, emission_cdf);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, energy_delta);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, active_ew_per_cell);
 JAYBENNE_FIELD_VARIABLE(field.jaybenne, active_num_per_cell);
+JAYBENNE_FIELD_VARIABLE(field.jaybenne, old_active_ew_per_cell);
 namespace host {
 typedef HOST_DENSITY density;
 typedef HOST_SPECIFIC_INTERNAL_ENERGY sie;

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -1,0 +1,194 @@
+//========================================================================================
+// (C) (or copyright) 2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+// Jaybenne includes
+#include "jaybenne.hpp"
+
+namespace jaybenne {
+
+//----------------------------------------------------------------------------------------
+//! \fn  TaskStatus ControlPopulation
+//! \brief Ensure particle population is near target user number of particles.
+//! This currently uses a very simple strategy of killing a particle based on a
+//! probability calculated from the number of active in excess of the number of source
+//! particles. The expectation value is then the number of source particles: N_rm ~ P_rm *
+//! N_act = (1 - N_src / N_act) * N_act = N_act - N_src The remaining particles then each
+//! have their energy weight renormalized.
+TaskStatus ControlPopulation(MeshData<Real> *md) {
+  namespace fj = field::jaybenne;
+  namespace ph = particle::photons;
+
+  auto pm = md->GetParentPointer();
+  auto &resolved_pkgs = pm->resolved_packages;
+  auto &jb_pkg = pm->packages.Get("jaybenne");
+  auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
+
+  // Create SparsePack
+  static auto desc = MakePackDescriptor<fj::active_ew_per_cell, fj::active_num_per_cell,
+                                        fj::source_num_per_cell>(resolved_pkgs.get());
+  auto vmesh = desc.GetPack(md);
+
+  // Create SwarmPacks
+  static auto pdesc_r = MakeSwarmPackDescriptor<ph::weight>(photons_swarm_name);
+  static auto pdesc_i = MakeSwarmPackDescriptor<ph::ijk>(photons_swarm_name);
+  auto ppack_r = pdesc_r.GetPack(md);
+  auto ppack_i = pdesc_i.GetPack(md);
+
+  // Indexing and dimensionality
+  const int &nparticles_per_pack = ppack_r.GetMaxFlatIndex();
+  const auto &ib = md->GetBoundsI(IndexDomain::interior);
+  const auto &jb = md->GetBoundsJ(IndexDomain::interior);
+  const auto &kb = md->GetBoundsK(IndexDomain::interior);
+  const int &nblocks = vmesh.GetNBlocks();
+  const int nx1 = ib.e - ib.s + 1;
+  const int nx2 = jb.e - jb.s + 1;
+  const int nx3 = kb.e - kb.s + 1;
+  const int num_cells = nx1 * nx2 * nx3;
+
+  //--------------------------------------------------------------------------------------
+  // reset active particle count and energy weight per cell to 0
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::zero-active-counts-1",
+      parthenon::DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+        vmesh(b, fj::active_ew_per_cell(), k, j, i) = 0.0;
+        vmesh(b, fj::active_num_per_cell(), k, j, i) = 0.0;
+      });
+
+  //--------------------------------------------------------------------------------------
+  // aggregate active particle count and energy per cell
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::active-ptcl-counts-1", DevExecSpace(), 0,
+      nparticles_per_pack, KOKKOS_LAMBDA(const int idx) {
+        auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
+        const auto &swarm_d = ppack_r.GetContext(b);
+        if (swarm_d.IsActive(n)) {
+
+          // logical location and weight of particle
+          const int &ip = ppack_i(b, ph::ijk(0), n);
+          const int &jp = ppack_i(b, ph::ijk(1), n);
+          const int &kp = ppack_i(b, ph::ijk(2), n);
+          const Real &ww = ppack_r(b, ph::weight(), n);
+
+          // add ew and 1 to active particle number at cell
+          Real &actew = vmesh(b, fj::active_ew_per_cell(), kp, jp, ip);
+          Kokkos::atomic_add(&actew, ww);
+          Real &actnum = vmesh(b, fj::active_num_per_cell(), kp, jp, ip);
+          Kokkos::atomic_add(&actnum, 1.0);
+        }
+      });
+
+  //--------------------------------------------------------------------------------------
+  // sample probability to mark particle for removal
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::active-ptcl-remove", DevExecSpace(), 0,
+      nparticles_per_pack, KOKKOS_LAMBDA(const int idx) {
+        auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
+        const auto &swarm_d = ppack_r.GetContext(b);
+        if (swarm_d.IsActive(n)) {
+
+          // logical location and weight of particle
+          const int &ip = ppack_i(b, ph::ijk(0), n);
+          const int &jp = ppack_i(b, ph::ijk(1), n);
+          const int &kp = ppack_i(b, ph::ijk(2), n);
+
+          // sample if particle is to be removed
+          const Real &actnum = vmesh(b, fj::active_num_per_cell(), kp, jp, ip);
+          const Real &srcnum = vmesh(b, fj::source_num_per_cell(), kp, jp, ip);
+          // TODO: fix this arbitrary hard-coded threshold
+          if (actnum > 4 * srcnum) {
+            auto rng_gen = rng_pool.get_state();
+            const Real rand = rng_gen.drand();
+            if (rand * actnum < actnum - 4 * srcnum) {
+              swarm_d.MarkParticleForRemoval(n);
+            }
+          }
+        }
+      });
+
+  //--------------------------------------------------------------------------------------
+  // removed marked particles
+  for (int b = 0; b <= nblocks - 1; ++b) {
+    md->GetSwarmData(b)->Get(photons_swarm_name)->RemoveMarkedParticles();
+  }
+
+  //--------------------------------------------------------------------------------------
+  // reset active particle count per cell to 0
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::zero-active-counts-2",
+      parthenon::DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
+        vmesh(b, fj::active_num_per_cell(), k, j, i) = 0.0;
+      });
+
+  //--------------------------------------------------------------------------------------
+  // store old active energy weight totals per cell, after particle removal
+  ParArray2D<Real> old_active_ew_per_cell("old active photon energy per cell per block",
+                                          nblocks, num_cells);
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::store-old-active-ew", DevExecSpace(), 0,
+      nparticles_per_pack, KOKKOS_LAMBDA(const int idx) {
+        auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
+        const auto &swarm_d = ppack_r.GetContext(b);
+        if (swarm_d.IsActive(n)) {
+
+          // logical location and weight of particle
+          const int &ip = ppack_i(b, ph::ijk(0), n);
+          const int &jp = ppack_i(b, ph::ijk(1), n);
+          const int &kp = ppack_i(b, ph::ijk(2), n);
+          const Real &ww = ppack_r(b, ph::weight(), n);
+
+          // get serialized block-local cell index
+          const int cell_idx =
+              (kp - kb.s) * (nx1 * nx2) + (jp - jb.s) * nx1 + (ip - ib.s);
+
+          // add ew and 1 to active particle number at cell
+          Real &actew = old_active_ew_per_cell(b, cell_idx);
+          Kokkos::atomic_add(&actew, ww);
+          Real &actnum = vmesh(b, fj::active_num_per_cell(), kp, jp, ip);
+          Kokkos::atomic_add(&actnum, 1.0);
+        }
+      });
+
+  //--------------------------------------------------------------------------------------
+  // renormalize surviving particle energy weights, to conserve energy
+  parthenon::par_for(
+      DEFAULT_LOOP_PATTERN, "ControlPopulation::renorm-ptcl-ew", DevExecSpace(), 0,
+      nparticles_per_pack, KOKKOS_LAMBDA(const int idx) {
+        auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
+        const auto &swarm_d = ppack_r.GetContext(b);
+        if (swarm_d.IsActive(n)) {
+
+          // logical location and weight of particle
+          const int &ip = ppack_i(b, ph::ijk(0), n);
+          const int &jp = ppack_i(b, ph::ijk(1), n);
+          const int &kp = ppack_i(b, ph::ijk(2), n);
+
+          // get serialized block-local cell index
+          const int cell_idx =
+              (kp - kb.s) * (nx1 * nx2) + (jp - jb.s) * nx1 + (ip - ib.s);
+
+          Real &ww = ppack_r(b, ph::weight(), n);
+
+          const Real &actew = vmesh(b, fj::active_ew_per_cell(), kp, jp, ip);
+          const Real &oldactew = old_active_ew_per_cell(b, cell_idx);
+
+          PARTHENON_DEBUG_REQUIRE(oldactew > 0.0, "Particle in cell with 0 particles!");
+          ww *= (actew / oldactew);
+        }
+      });
+
+  return TaskStatus::complete;
+}
+
+} // namespace jaybenne

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -71,7 +71,6 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
         auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
         const auto &swarm_d = ppack_r.GetContext(b);
         if (swarm_d.IsActive(n)) {
-
           // logical location and weight of particle
           const int &ip = ppack_i(b, ph::ijk(0), n);
           const int &jp = ppack_i(b, ph::ijk(1), n);

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -34,8 +34,10 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
 
   // Create SparsePack
-  static auto desc = MakePackDescriptor<fj::active_ew_per_cell, fj::active_num_per_cell,
-                                        fj::source_num_per_cell>(resolved_pkgs.get());
+  static auto desc =
+      MakePackDescriptor<fj::active_ew_per_cell, fj::active_num_per_cell,
+                         fj::old_active_ew_per_cell, fj::source_num_per_cell>(
+          resolved_pkgs.get());
   auto vmesh = desc.GetPack(md);
 
   // Create SwarmPacks
@@ -50,10 +52,6 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
   const auto &jb = md->GetBoundsJ(IndexDomain::interior);
   const auto &kb = md->GetBoundsK(IndexDomain::interior);
   const int &nblocks = vmesh.GetNBlocks();
-  const int nx1 = ib.e - ib.s + 1;
-  const int nx2 = jb.e - jb.s + 1;
-  const int nx3 = kb.e - kb.s + 1;
-  const int num_cells = nx1 * nx2 * nx3;
 
   //--------------------------------------------------------------------------------------
   // reset active particle count and energy weight per cell to 0
@@ -82,8 +80,8 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
 
           // add ew and 1 to active particle number at cell
           Real &actew = vmesh(b, fj::active_ew_per_cell(), kp, jp, ip);
-          Kokkos::atomic_add(&actew, ww);
           Real &actnum = vmesh(b, fj::active_num_per_cell(), kp, jp, ip);
+          Kokkos::atomic_add(&actew, ww);
           Kokkos::atomic_add(&actnum, 1.0);
         }
       });
@@ -96,7 +94,6 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
         auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
         const auto &swarm_d = ppack_r.GetContext(b);
         if (swarm_d.IsActive(n)) {
-
           // logical location and weight of particle
           const int &ip = ppack_i(b, ph::ijk(0), n);
           const int &jp = ppack_i(b, ph::ijk(1), n);
@@ -129,33 +126,27 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
       parthenon::DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i) {
         vmesh(b, fj::active_num_per_cell(), k, j, i) = 0.0;
+        vmesh(b, fj::old_active_ew_per_cell(), k, j, i) = 0.0;
       });
 
   //--------------------------------------------------------------------------------------
   // store old active energy weight totals per cell, after particle removal
-  ParArray2D<Real> old_active_ew_per_cell("old active photon energy per cell per block",
-                                          nblocks, num_cells);
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "ControlPopulation::store-old-active-ew", DevExecSpace(), 0,
       nparticles_per_pack, KOKKOS_LAMBDA(const int idx) {
         auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
         const auto &swarm_d = ppack_r.GetContext(b);
         if (swarm_d.IsActive(n)) {
-
           // logical location and weight of particle
           const int &ip = ppack_i(b, ph::ijk(0), n);
           const int &jp = ppack_i(b, ph::ijk(1), n);
           const int &kp = ppack_i(b, ph::ijk(2), n);
           const Real &ww = ppack_r(b, ph::weight(), n);
 
-          // get serialized block-local cell index
-          const int cell_idx =
-              (kp - kb.s) * (nx1 * nx2) + (jp - jb.s) * nx1 + (ip - ib.s);
-
           // add ew and 1 to active particle number at cell
-          Real &actew = old_active_ew_per_cell(b, cell_idx);
-          Kokkos::atomic_add(&actew, ww);
+          Real &actew = vmesh(b, fj::old_active_ew_per_cell(), kp, jp, ip);
           Real &actnum = vmesh(b, fj::active_num_per_cell(), kp, jp, ip);
+          Kokkos::atomic_add(&actew, ww);
           Kokkos::atomic_add(&actnum, 1.0);
         }
       });
@@ -168,21 +159,14 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
         auto [b, n] = ppack_r.GetBlockParticleIndices(idx);
         const auto &swarm_d = ppack_r.GetContext(b);
         if (swarm_d.IsActive(n)) {
-
           // logical location and weight of particle
           const int &ip = ppack_i(b, ph::ijk(0), n);
           const int &jp = ppack_i(b, ph::ijk(1), n);
           const int &kp = ppack_i(b, ph::ijk(2), n);
-
-          // get serialized block-local cell index
-          const int cell_idx =
-              (kp - kb.s) * (nx1 * nx2) + (jp - jb.s) * nx1 + (ip - ib.s);
-
           Real &ww = ppack_r(b, ph::weight(), n);
 
+          const Real &oldactew = vmesh(b, fj::old_active_ew_per_cell(), kp, jp, ip);
           const Real &actew = vmesh(b, fj::active_ew_per_cell(), kp, jp, ip);
-          const Real &oldactew = old_active_ew_per_cell(b, cell_idx);
-
           PARTHENON_DEBUG_REQUIRE(oldactew > 0.0, "Particle in cell with 0 particles!");
           ww *= (actew / oldactew);
         }

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -11,6 +11,9 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+// C++ includes
+#include <limits>
+
 // Jaybenne includes
 #include "jaybenne.hpp"
 #include "jaybenne_utils.hpp"
@@ -64,8 +67,9 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   // Create pack
   static auto desc =
       MakePackDescriptor<fjh::density, fjh::sie, fj::fleck_factor,
-                         fj::active_num_per_cell, fj::source_num_per_cell,
-                         fj::source_ew_per_cell, fj::emission_cdf, fj::energy_delta>(
+                         fj::source_num_per_cell, fj::source_ew_per_cell,
+                         fj::delta_num_per_cell, fj::active_num_per_cell,
+                         fj::active_ew_per_cell, fj::emission_cdf, fj::energy_delta>(
           resolved_pkgs.get());
   auto vmesh = desc.GetPack(md);
 
@@ -80,8 +84,8 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   const int nx2 = jb.e - jb.s + 1;
   const int nx3 = kb.e - kb.s + 1;
   const int num_cells = nx1 * nx2 * nx3;
-  const Real npc = static_cast<Real>(num_particles) / num_cells /
-                   (nblocks * md->GetMeshPointer()->nbtotal);
+  const Real npc = std::floor(static_cast<Real>(num_particles) /
+                              (num_cells * md->GetMeshPointer()->nbtotal));
 
   ParArray1D<int> nparticles("# particles per block", nblocks);
   ParArray2D<int> prefix_sum("prefix sums per block", nblocks, num_cells);
@@ -94,7 +98,6 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
         par_reduce_inner(
             member, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
             [&](const int &k, const int &j, const int &i, int &ntot) {
-              auto rng_gen = rng_pool.get_state();
               // Compute erad
               const Real &rho = vmesh(b, fjh::density(), k, j, i);
               const Real &sie = vmesh(b, fjh::sie(), k, j, i);
@@ -145,14 +148,19 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
                 }
                 erad = vmesh(b, fj::fleck_factor(), k, j, i) * emis * dv * dtd;
               }
-              // Set source_num_per_cell
+
+              // Sourcing
               Real &snpc = vmesh(b, fj::source_num_per_cell(), k, j, i);
+              Real &sewpc = vmesh(b, fj::source_ew_per_cell(), k, j, i);
               Real &actnum = vmesh(b, fj::active_num_per_cell(), k, j, i);
-              snpc = std::floor(npc);
-              const Real pdiff = snpc - actnum;
-              ntot += static_cast<int>(pdiff);
-              vmesh(b, fj::source_ew_per_cell(), k, j, i) = erad / snpc;
-              rng_pool.free_state(rng_gen);
+              Real &dnum = vmesh(b, fj::delta_num_per_cell(), k, j, i);
+              // NOTE(PDM): We hardcode snpc and sewpc below, but we could imagine
+              // introducing supplementary functions/tasks that set these, or even
+              // giving downstream codes the opportunity to set these themselves...
+              snpc = npc;
+              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), 20.0);
+              sewpc = erad / dnum;
+              ntot += static_cast<int>(dnum);
             },
             Kokkos::Sum<int>(block_sum));
         Kokkos::single(Kokkos::PerTeam(member), [&]() { nparticles(b) = block_sum; });
@@ -164,8 +172,8 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
                                 int j = (idx / nx1) % nx2 + jb.s;
                                 int i = idx % nx1 + ib.s;
                                 if (finale) prefix_sum(b, idx) = update;
-                                update += static_cast<int>(std::round(
-                                    vmesh(b, fj::source_num_per_cell(), k, j, i)));
+                                update += static_cast<int>(
+                                    vmesh(b, fj::delta_num_per_cell(), k, j, i));
                               });
       });
   Kokkos::fence();
@@ -214,12 +222,12 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
         // Starting index and length of particles in this cell
         const int &pstart_idx = prefix_sum(b, cell_idx_1d);
-        const int num_part_per_cell =
-            static_cast<int>(std::round(vmesh(b, fj::source_num_per_cell(), k, j, i)));
+        const int new_part_per_cell =
+            static_cast<int>(vmesh(b, fj::delta_num_per_cell(), k, j, i));
 
         Real &dejbn = vmesh(b, fj::energy_delta(), k, j, i);
         dejbn = 0.0;
-        for (int np = pstart_idx; np < pstart_idx + num_part_per_cell; np++) {
+        for (int np = pstart_idx; np < pstart_idx + new_part_per_cell; np++) {
           const int &n = new_contexts(b).GetNewParticleIndex(np);
           ppack_i(b, ph::ijk(0), n) = i;
           ppack_i(b, ph::ijk(1), n) = j;
@@ -264,9 +272,9 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
           }
 
           if constexpr (ST == SourceType::emission) {
-            dejbn -= ppack_r(b, ph::weight(), n);
             // Sample uniformly over timestep
             ppack_r(b, ph::time(), n) = t_startd + rng_gen.drand() * dtd;
+            dejbn -= ppack_r(b, ph::weight(), n);
           } else {
             ppack_r(b, ph::time(), n) = 0.;
           }
@@ -280,25 +288,29 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
 //----------------------------------------------------------------------------------------
 //! template instantiations
-typedef MeshBlockData<Real> BD;
-typedef MeshData<Real> D;
-typedef SourceType ST;
-typedef FrequencyType FT;
-template TaskStatus SourcePhotons<BD, ST::thermal, FT::gray>(BD *md, const Real t0,
-                                                             const Real dt);
-template TaskStatus SourcePhotons<BD, ST::emission, FT::gray>(BD *md, const Real t0,
-                                                              const Real dt);
-template TaskStatus SourcePhotons<D, ST::thermal, FT::gray>(D *md, const Real t0,
-                                                            const Real dt);
-template TaskStatus SourcePhotons<D, ST::emission, FT::gray>(D *md, const Real t0,
-                                                             const Real dt);
-template TaskStatus SourcePhotons<BD, ST::thermal, FT::multigroup>(BD *md, const Real t0,
-                                                                   const Real dt);
-template TaskStatus SourcePhotons<BD, ST::emission, FT::multigroup>(BD *md, const Real t0,
-                                                                    const Real dt);
-template TaskStatus SourcePhotons<D, ST::thermal, FT::multigroup>(D *md, const Real t0,
-                                                                  const Real dt);
-template TaskStatus SourcePhotons<D, ST::emission, FT::multigroup>(D *md, const Real t0,
-                                                                   const Real dt);
+template TaskStatus
+SourcePhotons<MeshBlockData<Real>, SourceType::thermal, FrequencyType::gray>(
+    MeshBlockData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshBlockData<Real>, SourceType::emission, FrequencyType::gray>(
+    MeshBlockData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshData<Real>, SourceType::thermal, FrequencyType::gray>(
+    MeshData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshData<Real>, SourceType::emission, FrequencyType::gray>(
+    MeshData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshBlockData<Real>, SourceType::thermal, FrequencyType::multigroup>(
+    MeshBlockData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshBlockData<Real>, SourceType::emission, FrequencyType::multigroup>(
+    MeshBlockData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshData<Real>, SourceType::thermal, FrequencyType::multigroup>(
+    MeshData<Real> *md, const Real t0, const Real dt);
+template TaskStatus
+SourcePhotons<MeshData<Real>, SourceType::emission, FrequencyType::multigroup>(
+    MeshData<Real> *md, const Real t0, const Real dt);
 
 } // namespace jaybenne

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -63,8 +63,9 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
   // Create pack
   static auto desc =
-      MakePackDescriptor<fjh::density, fjh::sie, fj::fleck_factor, fj::source_ew_per_cell,
-                         fj::source_num_per_cell, fj::emission_cdf, fj::energy_delta>(
+      MakePackDescriptor<fjh::density, fjh::sie, fj::fleck_factor,
+                         fj::active_num_per_cell, fj::source_num_per_cell,
+                         fj::source_ew_per_cell, fj::emission_cdf, fj::energy_delta>(
           resolved_pkgs.get());
   auto vmesh = desc.GetPack(md);
 
@@ -146,9 +147,10 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
               }
               // Set source_num_per_cell
               Real &snpc = vmesh(b, fj::source_num_per_cell(), k, j, i);
+              Real &actnum = vmesh(b, fj::active_num_per_cell(), k, j, i);
               snpc = std::floor(npc);
-              snpc += ((npc - snpc) > rng_gen.drand());
-              ntot += static_cast<int>(std::round(snpc));
+              const Real pdiff = snpc - actnum;
+              ntot += static_cast<int>(pdiff);
               vmesh(b, fj::source_ew_per_cell(), k, j, i) = erad / snpc;
               rng_pool.free_state(rng_gen);
             },

--- a/src/jaybenne/transport.cpp
+++ b/src/jaybenne/transport.cpp
@@ -96,9 +96,9 @@ TaskStatus TransportPhotons(MeshData<Real> *md, const Real t_start, const Real d
 
           auto rng_gen = rng_pool.get_state();
           auto &coords = vmesh.GetCoordinates(b);
-          const Real &dx_i = coords.Dxc<X1DIR>(0, 0, 0);
-          const Real &dx_j = coords.Dxc<X2DIR>(0, 0, 0);
-          const Real &dx_k = coords.Dxc<X3DIR>(0, 0, 0);
+          const Real &dx_i = coords.template Dxc<parthenon::X1DIR>(0, 0, 0);
+          const Real &dx_j = coords.template Dxc<parthenon::X2DIR>(0, 0, 0);
+          const Real &dx_k = coords.template Dxc<parthenon::X3DIR>(0, 0, 0);
           const Real dx_push = std::min(dx_i, std::min(dx_j, dx_k));
 
           // Particle properties

--- a/src/jaybenne/transport.cpp
+++ b/src/jaybenne/transport.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -77,9 +77,9 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
         if (swarm_d.IsActive(n)) {
           auto rng_gen = rng_pool.get_state();
           auto &coords = vmesh.GetCoordinates(b);
-          const Real &dx_i = coords.Dxc<X1DIR>(0, 0, 0);
-          const Real &dx_j = coords.Dxc<X2DIR>(0, 0, 0);
-          const Real &dx_k = coords.Dxc<X3DIR>(0, 0, 0);
+          const Real &dx_i = coords.template Dxc<parthenon::X1DIR>(0, 0, 0);
+          const Real &dx_j = coords.template Dxc<parthenon::X2DIR>(0, 0, 0);
+          const Real &dx_k = coords.template Dxc<parthenon::X3DIR>(0, 0, 0);
           const Real dx_push = std::min(dx_i, std::min(dx_j, dx_k));
 
           // Particle properties

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
## Background

* @pdmullen recently discovered that the particle population size is unchecked.
* Some mechanism for removing active particles is needed to avoid arbitrary population growth.
* This change set attempts to do so (described below).
  * This has the changes from PR #5, so it is marked `Draft` until that PR is merged.

## Description of Changes

+ Add active particle total energy weight and number fields.
+ Add ContolPopulation task, invoked at end of each time step.
+ Use 4x[source number per cell] as threshold to remove particles.
+ Renormalize remaining active particle energies to conserve energy.
+ Update active particle cell energy weight and number per cell.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [x] (@lanl.gov employees) Update copyright on changed files

