### PR TITLE
Avoid pushing near-boundary particle out of cell if a collision is sampled

### DIFF
--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -148,15 +148,16 @@ void ptcl_transport_step(tran_step_args tra) {
   tra.z += tra.three_d * tra.vz * dt_push;
 
   // handle faces
+  const bool leave = !(tra.is_absorbed || tra.is_scattered);
   const Real fdx = eps_imc_offset * (tra.xu - tra.xl);
   const Real fdy = eps_imc_offset * (tra.yu - tra.yl);
   const Real fdz = eps_imc_offset * (tra.zu - tra.zl);
-  tra.x = (std::abs(tra.x - tra.xl) < fdx) ? tra.xl - fdx : tra.x;
-  tra.x = (std::abs(tra.x - tra.xu) < fdx) ? tra.xu + fdx : tra.x;
-  tra.y = (tra.multi_d && std::abs(tra.y - tra.yl) < fdy) ? tra.yl - fdy : tra.y;
-  tra.y = (tra.multi_d && std::abs(tra.y - tra.yu) < fdy) ? tra.yu + fdy : tra.y;
-  tra.z = (tra.three_d && std::abs(tra.z - tra.zl) < fdz) ? tra.zl - fdz : tra.z;
-  tra.z = (tra.three_d && std::abs(tra.z - tra.zu) < fdz) ? tra.zu + fdz : tra.z;
+  tra.x = (std::abs(tra.x - tra.xl) < fdx && leave) ? tra.xl - fdx : tra.x;
+  tra.x = (std::abs(tra.x - tra.xu) < fdx && leave) ? tra.xu + fdx : tra.x;
+  tra.y = (tra.multi_d && std::abs(tra.y - tra.yl) < fdy && leave) ? tra.yl - fdy : tra.y;
+  tra.y = (tra.multi_d && std::abs(tra.y - tra.yu) < fdy && leave) ? tra.yu + fdy : tra.y;
+  tra.z = (tra.three_d && std::abs(tra.z - tra.zl) < fdz && leave) ? tra.zl - fdz : tra.z;
+  tra.z = (tra.three_d && std::abs(tra.z - tra.zu) < fdz && leave) ? tra.zu + fdz : tra.z;
 }
 
 // TODO(RTW): add effective out-scattering from DDMC when multigroup is enabled

--- a/src/mcblock/mcblock.cpp
+++ b/src/mcblock/mcblock.cpp
@@ -108,24 +108,28 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string opacity_model = pin->GetString("mcblock", "opacity_model");
   if (frequency_type == FrequencyType::gray) {
     if (opacity_model == "none") {
-      auto opac = singularity::photons::Gray(1.e-100);
+      auto opac = singularity::photons::NonCGSUnits<singularity::photons::Gray>(
+          singularity::photons::Gray(1.e-100), time_scale, mass_scale, length_scale,
+          temperature_scale);
       mopacity =
           singularity::photons::MeanNonCGSUnits<singularity::photons::MeanOpacityBase>(
               singularity::photons::MeanOpacityBase(opac, -1, 1, 2, -1, 1, 2), time_scale,
-              mass_scale, length_scale, 1.);
+              mass_scale, length_scale, temperature_scale);
     } else if (opacity_model == "constant") {
       Real kappa = pin->GetReal("mcblock", "opacity_constant_value");
-      auto opac = singularity::photons::Gray(kappa);
+      auto opac = singularity::photons::NonCGSUnits<singularity::photons::Gray>(
+          singularity::photons::Gray(kappa), time_scale, mass_scale, length_scale,
+          temperature_scale);
       mopacity =
           singularity::photons::MeanNonCGSUnits<singularity::photons::MeanOpacityBase>(
               singularity::photons::MeanOpacityBase(opac, -1, 1, 2, -1, 1, 2), time_scale,
-              mass_scale, length_scale, 1.);
+              mass_scale, length_scale, temperature_scale);
     } else if (opacity_model == "table") {
       std::string table_filename = pin->GetString("mcblock", "opacity_table");
       mopacity =
           singularity::photons::MeanNonCGSUnits<singularity::photons::MeanOpacityBase>(
               singularity::photons::MeanOpacityBase(table_filename), time_scale,
-              mass_scale, length_scale, 1.);
+              mass_scale, length_scale, temperature_scale);
     } else {
       PARTHENON_FAIL("Only none, constant, or table opacity models supported!");
     }

--- a/src/mcblock/mcblock.cpp
+++ b/src/mcblock/mcblock.cpp
@@ -108,18 +108,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string opacity_model = pin->GetString("mcblock", "opacity_model");
   if (frequency_type == FrequencyType::gray) {
     if (opacity_model == "none") {
-      auto opac = singularity::photons::NonCGSUnits<singularity::photons::Gray>(
-          singularity::photons::Gray(1.e-100), time_scale, mass_scale, length_scale,
-          temperature_scale);
+      auto opac = singularity::photons::Gray(1.e-100);
       mopacity =
           singularity::photons::MeanNonCGSUnits<singularity::photons::MeanOpacityBase>(
               singularity::photons::MeanOpacityBase(opac, -1, 1, 2, -1, 1, 2), time_scale,
               mass_scale, length_scale, temperature_scale);
     } else if (opacity_model == "constant") {
       Real kappa = pin->GetReal("mcblock", "opacity_constant_value");
-      auto opac = singularity::photons::NonCGSUnits<singularity::photons::Gray>(
-          singularity::photons::Gray(kappa), time_scale, mass_scale, length_scale,
-          temperature_scale);
+      auto opac = singularity::photons::Gray(kappa);
       mopacity =
           singularity::photons::MeanNonCGSUnits<singularity::photons::MeanOpacityBase>(
               singularity::photons::MeanOpacityBase(opac, -1, 1, 2, -1, 1, 2), time_scale,


### PR DESCRIPTION
## Background

* Particles can be within a tolerance level of a cell boundary that induces getting pushed across the cell.

## Description of Changes

* Check if particle has not scattered or absorbed before being pushed epsilon across boundary
* ~Instantiate opacity model used in mean opacity with non-cgs opacity variants.~

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

