### PR TITLE
Fix DDMC->IMC block-block transition, for coarse(r) current block; fix DDMC near-hang pathology.

### DIFF
--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -164,6 +164,9 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
 
     // Control particle population
     auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get());
+
+    // Defrag particles?
+    auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles, base.get());
   }
 
   auto &timing_region1 = tc.AddRegion(1);
@@ -662,13 +665,26 @@ TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt) {
 //! \brief  NOTE(PDM): currently unused???
 //! TODO(BRR) We should re-enable this but add a runtime parameter that sets the
 //! fractional fragmentation of the memory pool above which we defragment.
-TaskStatus DefragParticles(MeshBlock *pmb) {
-  auto &jbn = pmb->packages.Get("jaybenne");
+TaskStatus DefragParticles(MeshData<Real> *md) {
+  namespace fj = field::jaybenne;
+  namespace ph = particle::photons;
+
+  auto pm = md->GetParentPointer();
+  auto &resolved_pkgs = pm->resolved_packages;
+  auto &jbn = pm->packages.Get("jaybenne");
+
+  // Create SparsePack
+  static auto desc = MakePackDescriptor<fj::energy_tally>(resolved_pkgs.get());
+  auto vmesh = desc.GetPack(md);
+
+  const int &nblocks = vmesh.GetNBlocks();
   auto &min_swarm_occupancy = jbn->template Param<Real>("min_swarm_occupancy");
-  auto &swarm = pmb->meshblock_data.Get()->GetSwarmData()->Get(photons_swarm_name);
-  if (swarm->GetNumActive() > 0) {
-    if (swarm->GetPackingEfficiency() < min_swarm_occupancy) {
-      swarm->Defrag();
+  for (int b = 0; b <= nblocks - 1; ++b) {
+    auto &swarm = md->GetSwarmData(b)->Get(photons_swarm_name);
+    if (swarm->GetNumActive() > 0) {
+      if (swarm->GetPackingEfficiency() < min_swarm_occupancy) {
+        swarm->Defrag();
+      }
     }
   }
   return TaskStatus::complete;

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -166,8 +166,7 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
     auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get());
 
     // TODO: Defrag particles? Verify parth swarm defrag mechanics before uncommenting
-    // this. auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles,
-    // base.get());
+    // auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles, base.get());
   }
 
   auto &timing_region1 = tc.AddRegion(1);

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -165,8 +165,9 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
     // Control particle population
     auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get());
 
-    // Defrag particles?
-    auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles, base.get());
+    // TODO: Defrag particles? Verify parth swarm defrag mechanics before uncommenting
+    // this. auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles,
+    // base.get());
   }
 
   auto &timing_region1 = tc.AddRegion(1);
@@ -671,7 +672,7 @@ TaskStatus DefragParticles(MeshData<Real> *md) {
   auto &jbn = pm->packages.Get("jaybenne");
   auto &min_swarm_occupancy = jbn->template Param<Real>("min_swarm_occupancy");
   const int nblocks = md->NumBlocks();
-  
+
   for (int b = 0; b <= nblocks - 1; ++b) {
     auto &swarm = md->GetSwarmData(b)->Get(photons_swarm_name);
     if (swarm->GetNumActive() > 0) {

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -666,19 +666,12 @@ TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt) {
 //! TODO(BRR) We should re-enable this but add a runtime parameter that sets the
 //! fractional fragmentation of the memory pool above which we defragment.
 TaskStatus DefragParticles(MeshData<Real> *md) {
-  namespace fj = field::jaybenne;
-  namespace ph = particle::photons;
-
   auto pm = md->GetParentPointer();
   auto &resolved_pkgs = pm->resolved_packages;
   auto &jbn = pm->packages.Get("jaybenne");
-
-  // Create SparsePack
-  static auto desc = MakePackDescriptor<fj::energy_tally>(resolved_pkgs.get());
-  auto vmesh = desc.GetPack(md);
-
-  const int &nblocks = vmesh.GetNBlocks();
   auto &min_swarm_occupancy = jbn->template Param<Real>("min_swarm_occupancy");
+  const int nblocks = md->NumBlocks();
+  
   for (int b = 0; b <= nblocks - 1; ++b) {
     auto &swarm = md->GetSwarmData(b)->Get(photons_swarm_name);
     if (swarm->GetNumActive() > 0) {

--- a/src/jaybenne/jaybenne.hpp
+++ b/src/jaybenne/jaybenne.hpp
@@ -79,7 +79,7 @@ TaskStatus SampleDDMCBlockFace(MeshData<Real> *md);
 TaskStatus CheckCompletion(MeshData<Real> *md, const Real t_end);
 template <typename T, SourceType ST, FrequencyType FT>
 TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt);
-TaskStatus DefragParticles(MeshBlock *pmb);
+TaskStatus DefragParticles(MeshData<Real> *md);
 TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt);
 template <typename T>
 TaskStatus EvaluateRadiationEnergy(T *md);

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -201,6 +201,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   auto ppack_i = pdesc_i.GetPack(md);
 
   constexpr Real eps = 4.0e8 * parthenon::robust::EPS();
+  const Real ome = 1.0 - eps;
 
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "SourcePhotons2", parthenon::DevExecSpace(), 0, nblocks - 1,
@@ -244,12 +245,10 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
           // Sample position uniformly in space over cell
           // TODO(BRR) only valid for Cartesian
-          ppack_r(b, swarm_position::x(), n) =
-              xi + dx_i * (1.0 - eps) * (rng_gen.drand() - 0.5);
-          ppack_r(b, swarm_position::y(), n) =
-              yi + dx_j * (1.0 - eps) * (rng_gen.drand() - 0.5);
-          ppack_r(b, swarm_position::z(), n) =
-              zi + dx_k * (1.0 - eps) * (rng_gen.drand() - 0.5);
+          const Real one_minus_eps = ;
+          ppack_r(b, swarm_position::x(), n) = xi + dx_i * ome * (rng_gen.drand() - 0.5);
+          ppack_r(b, swarm_position::y(), n) = yi + dx_j * ome * (rng_gen.drand() - 0.5);
+          ppack_r(b, swarm_position::z(), n) = zi + dx_k * ome * (rng_gen.drand() - 0.5);
 
           // Sample direction uniformly in solid angle
           const Real theta = std::acos(2.0 * rng_gen.drand() - 1.0);

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -14,6 +14,9 @@
 // C++ includes
 #include <limits>
 
+// Parthenon includes
+#include <utils/robust.hpp>
+
 // Jaybenne includes
 #include "jaybenne.hpp"
 #include "jaybenne_utils.hpp"
@@ -197,6 +200,8 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   auto ppack_r = pdesc_r.GetPack(md);
   auto ppack_i = pdesc_i.GetPack(md);
 
+  constexpr Real eps = 4.0e8 * parthenon::robust::EPS();
+
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "SourcePhotons2", parthenon::DevExecSpace(), 0, nblocks - 1,
       kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
@@ -239,9 +244,12 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
           // Sample position uniformly in space over cell
           // TODO(BRR) only valid for Cartesian
-          ppack_r(b, swarm_position::x(), n) = xi + dx_i * (rng_gen.drand() - 0.5);
-          ppack_r(b, swarm_position::y(), n) = yi + dx_j * (rng_gen.drand() - 0.5);
-          ppack_r(b, swarm_position::z(), n) = zi + dx_k * (rng_gen.drand() - 0.5);
+          ppack_r(b, swarm_position::x(), n) =
+              xi + dx_i * (1.0 - eps) * (rng_gen.drand() - 0.5);
+          ppack_r(b, swarm_position::y(), n) =
+              yi + dx_j * (1.0 - eps) * (rng_gen.drand() - 0.5);
+          ppack_r(b, swarm_position::z(), n) =
+              zi + dx_k * (1.0 - eps) * (rng_gen.drand() - 0.5);
 
           // Sample direction uniformly in solid angle
           const Real theta = std::acos(2.0 * rng_gen.drand() - 1.0);

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -245,7 +245,6 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
 
           // Sample position uniformly in space over cell
           // TODO(BRR) only valid for Cartesian
-          const Real one_minus_eps = ;
           ppack_r(b, swarm_position::x(), n) = xi + dx_i * ome * (rng_gen.drand() - 0.5);
           ppack_r(b, swarm_position::y(), n) = yi + dx_j * ome * (rng_gen.drand() - 0.5);
           ppack_r(b, swarm_position::z(), n) = zi + dx_k * ome * (rng_gen.drand() - 0.5);

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -58,6 +58,9 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
   auto ppack_r = pdesc_r.GetPack(md);
   auto ppack_i = pdesc_i.GetPack(md);
 
+  // set tolerance for checking particle 0-velocity (i.e. if from DDMC block)
+  constexpr Real eps = parthenon::robust::EPS();
+
   // Indexing and dimensionality
   const auto &ib = md->GetBoundsI(IndexDomain::interior);
   const auto &jb = md->GetBoundsJ(IndexDomain::interior);
@@ -197,9 +200,9 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
                                   t, x, y, z, is_absorbed, is_scattered};
 
               // if velocity is 0, particle is from a DDMC cell in another block at <= refinement
-              if (vx * vx + vy * vy + vz * vz < 0.5 * vv * vv) ptcl_ddmc_to_imc(tra);
-              PARTHENON_REQUIRE(vx * vx + vy * vy + vz * vz > 0.5 * vv * vv,
-                               "Invalid velocity: lower than lightspeed");
+              if (vx * vx + vy * vy + vz * vz < eps * vv * vv) ptcl_ddmc_to_imc(tra);
+              PARTHENON_DEBUG_REQUIRE(vx * vx + vy * vy + vz * vz > 0.5 * vv * vv,
+                                      "Invalid velocity: lower than lightspeed");
 
               // clang-format on
               ptcl_transport_step(tra);

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -43,6 +43,7 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
   auto &mscattering = jb_pkg->template Param<MeanScattering>("mscattering_d");
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
   const Real vv = jb_pkg->template Param<Real>("speed_of_light");
+  const Real ske = 0.5 * SQR(vv);
   const Real &tau_ddmc = jb_pkg->template Param<Real>("tau_ddmc");
 
   // Create SparsePack
@@ -179,10 +180,8 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
                                   ip, jp, kp, is_absorbed, is_scattered};
               // clang-format on
 
-              // check for IMC-DDMC albedo rejection if this particle just arrived from an
-              // IMC region
-              if (vx * vx + vy * vy + vz * vz > 0.5 * vv * vv)
-                ptcl_ddmc_albedo(dia, is_rejected);
+              // check for IMC-DDMC albedo rejection if particle arrived from IMC region
+              if (SQR(vx) + SQR(vy) + SQR(vz) > ske) ptcl_ddmc_albedo(dia, is_rejected);
 
               if (!is_rejected) ptcl_ddmc_step(dia);
 
@@ -200,9 +199,9 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
                                   // updated by push
                                   t, x, y, z, is_absorbed, is_scattered};
 
-              // if velocity is 0, particle is from a DDMC cell in another block at <= refinement
-              if (vx * vx + vy * vy + vz * vz < eps * vv * vv) ptcl_ddmc_to_imc(tra);
-              PARTHENON_DEBUG_REQUIRE(vx * vx + vy * vy + vz * vz > 0.5 * vv * vv,
+              // if v==0, particle is from a DDMC cell in another block at <= refinement
+              if (SQR(vx) + SQR(vy) + SQR(vz) < 2.0 * eps * ske) ptcl_ddmc_to_imc(tra);
+              PARTHENON_DEBUG_REQUIRE(SQR(vx) + SQR(vy) + SQR(vz) > ske,
                                       "Invalid velocity: lower than lightspeed");
 
               // clang-format on

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -181,7 +181,8 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
 
               // check for IMC-DDMC albedo rejection if this particle just arrived from an
               // IMC region
-              ptcl_ddmc_albedo(dia, is_rejected);
+              if (vx * vx + vy * vy + vz * vz > 0.5 * vv * vv)
+                ptcl_ddmc_albedo(dia, is_rejected);
 
               if (!is_rejected) ptcl_ddmc_step(dia);
 

--- a/src/jaybenne/transport_ddmc.cpp
+++ b/src/jaybenne/transport_ddmc.cpp
@@ -183,6 +183,7 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
               if (!is_rejected) ptcl_ddmc_step(dia);
 
             } else {
+
               // push particle
               // clang-format off
               tran_step_args tra{ // constants
@@ -194,6 +195,12 @@ TaskStatus TransportPhotons_DDMC(MeshData<Real> *md, const Real t_start, const R
                                   xl, yl, zl, xu, yu, zu,
                                   // updated by push
                                   t, x, y, z, is_absorbed, is_scattered};
+
+              // if velocity is 0, particle is from a DDMC cell in another block at <= refinement
+              if (vx * vx + vy * vy + vz * vz < 0.5 * vv * vv) ptcl_ddmc_to_imc(tra);
+              PARTHENON_REQUIRE(vx * vx + vy * vy + vz * vz > 0.5 * vv * vv,
+                               "Invalid velocity: lower than lightspeed");
+
               // clang-format on
               ptcl_transport_step(tra);
             }

--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -287,7 +287,6 @@ void ptcl_ddmc_step(ddmc_step_args dia) {
 
 KOKKOS_FORCEINLINE_FUNCTION
 void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
-
   constexpr Real lam_ext = 0.7104;
   const Real dx = dia.xu - dia.xl;
   const Real dy = dia.yu - dia.yl;
@@ -303,18 +302,16 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
   }
 
   // IMC->DDMC entry conditions at each cell face
-  const bool lowx =
-      (dia.vx > 0.0 && fuzzy_equal(dia.x, dia.xl, dx, 2.5 * eps_imc_offset));
-  const bool higx =
-      (!(dia.vx > 0.0) && fuzzy_equal(dia.x, dia.xu, dx, 2.5 * eps_imc_offset));
-  const bool lowy =
-      (dia.vy > 0.0 && fuzzy_equal(dia.y, dia.yl, dy, 2.5 * eps_imc_offset));
-  const bool higy =
-      (!(dia.vy > 0.0) && fuzzy_equal(dia.y, dia.yu, dy, 2.5 * eps_imc_offset));
-  const bool lowz =
-      (dia.vz > 0.0 && fuzzy_equal(dia.z, dia.zl, dz, 2.5 * eps_imc_offset));
-  const bool higz =
-      (!(dia.vz > 0.0) && fuzzy_equal(dia.z, dia.zu, dz, 2.5 * eps_imc_offset));
+  const bool vxp = (dia.vx > 0.0);
+  const bool vyp = (dia.vy > 0.0);
+  const bool vzp = (dia.vz > 0.0);
+  const Real w_eps_imc_offset = 2.5 * eps_imc_offset;
+  const bool lowx = (vxp && fuzzy_equal(dia.x, dia.xl, dx, w_eps_imc_offset));
+  const bool higx = (!vxp && fuzzy_equal(dia.x, dia.xu, dx, w_eps_imc_offset));
+  const bool lowy = (vyp && fuzzy_equal(dia.y, dia.yl, dy, w_eps_imc_offset));
+  const bool higy = (!vyp && fuzzy_equal(dia.y, dia.yu, dy, w_eps_imc_offset));
+  const bool lowz = (vzp && fuzzy_equal(dia.z, dia.zl, dz, w_eps_imc_offset));
+  const bool higz = (!vzp && fuzzy_equal(dia.z, dia.zu, dz, w_eps_imc_offset));
 
   // check that coordinate is at cell edge (only possible coming from IMC)
   if (lowx) {

--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -112,7 +112,7 @@ KOKKOS_FORCEINLINE_FUNCTION
 void ptcl_transport_step(tran_step_args tra) {
 
   // use distances and convert to time after min is determined to reduce division ops
-  const Real rmin = std::numeric_limits<Real>::min();
+  constexpr Real rmin = std::numeric_limits<Real>::min();
   const Real lam_abs = 1.0 / (tra.ff * tra.aa + rmin);
   const Real lam_sc = 1.0 / (tra.ss + (1.0 - tra.ff) * tra.aa + rmin);
   const Real dx_abs = -lam_abs * std::log(tra.rng_gen.drand());
@@ -146,6 +146,10 @@ void ptcl_transport_step(tran_step_args tra) {
   tra.x += tra.vx * dt_push;
   tra.y += tra.multi_d * tra.vy * dt_push;
   tra.z += tra.three_d * tra.vz * dt_push;
+
+  // push time slightly into next time step if particle is at end of time step (census)
+  const bool is_atend = fuzzy_equal(tra.t, tra.t_start + tra.dt, tra.dt, eps_imc_offset);
+  tra.t = is_atend ? tra.t_start + (1.0 + eps_imc_offset) * tra.dt : tra.t;
 
   // handle faces
   const bool leave = !(tra.is_absorbed || tra.is_scattered);
@@ -275,6 +279,9 @@ void ptcl_ddmc_step(ddmc_step_args dia) {
     dia.vz = dia.vv * mu;
     dia.vx = dia.vv * nu * std::cos(phi);
     dia.vy = dia.vv * nu * std::sin(phi);
+
+    // ensure time is slightly past census time (TODO: use eps_ddmc_offset?)
+    dia.t = dia.t_start + (1.0 + eps_imc_offset) * dia.dt;
   }
 }
 
@@ -286,8 +293,31 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
   const Real dy = dia.yu - dia.yl;
   const Real dz = dia.zu - dia.zl;
 
+  // permit into DDMC automatically if originating from census
+  if (fuzzy_equal(dia.t, dia.t_start, dia.dt, 2.0 * eps_imc_offset)) {
+    dia.x = 0.5 * (dia.xl + dia.xu);
+    dia.y = 0.5 * (dia.yl + dia.yu);
+    dia.z = 0.5 * (dia.zl + dia.zu);
+    is_rejected = false;
+    return;
+  }
+
+  // IMC->DDMC entry conditions at each cell face
+  const bool lowx =
+      (dia.vx > 0.0 && fuzzy_equal(dia.x, dia.xl, dx, 2.5 * eps_imc_offset));
+  const bool higx =
+      (!(dia.vx > 0.0) && fuzzy_equal(dia.x, dia.xu, dx, 2.5 * eps_imc_offset));
+  const bool lowy =
+      (dia.vy > 0.0 && fuzzy_equal(dia.y, dia.yl, dy, 2.5 * eps_imc_offset));
+  const bool higy =
+      (!(dia.vy > 0.0) && fuzzy_equal(dia.y, dia.yu, dy, 2.5 * eps_imc_offset));
+  const bool lowz =
+      (dia.vz > 0.0 && fuzzy_equal(dia.z, dia.zl, dz, 2.5 * eps_imc_offset));
+  const bool higz =
+      (!(dia.vz > 0.0) && fuzzy_equal(dia.z, dia.zu, dz, 2.5 * eps_imc_offset));
+
   // check that coordinate is at cell edge (only possible coming from IMC)
-  if (fuzzy_equal(dia.x, dia.xl, dx, 2.5 * eps_imc_offset)) {
+  if (lowx) {
     // lower x-face
 
     // vx should be non-negative
@@ -299,12 +329,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vx, dia.vy, dia.vz);
       // set particle z position slightly above face
-      dia.x = dia.xl - eps_imc_offset * dx;
+      dia.x = dia.xl - eps_ddmc_offset * dx;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.x, dia.xu, dx, 2.5 * eps_imc_offset)) {
+  } else if (higx) {
     // upper x-face
 
     // vx should be non-positive
@@ -316,12 +346,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vx, dia.vy, dia.vz);
       // set particle z position slightly above face
-      dia.x = dia.xu + eps_imc_offset * dx;
+      dia.x = dia.xu + eps_ddmc_offset * dx;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.y, dia.yl, dy, 2.5 * eps_imc_offset) && dia.multi_d) {
+  } else if (lowy && dia.multi_d) {
     // lower y-face
 
     // vy should be non-negative
@@ -333,12 +363,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vy, dia.vz, dia.vx);
       // set particle y position slightly above face
-      dia.y = dia.yl - eps_imc_offset * dy;
+      dia.y = dia.yl - eps_ddmc_offset * dy;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.y, dia.yu, dy, 2.5 * eps_imc_offset) && dia.multi_d) {
+  } else if (higy && dia.multi_d) {
     // upper y-face
 
     // vy should be non-positive
@@ -350,12 +380,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vy, dia.vz, dia.vx);
       // set particle y position slightly above face
-      dia.y = dia.yu + eps_imc_offset * dy;
+      dia.y = dia.yu + eps_ddmc_offset * dy;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.z, dia.zl, dz, 2.5 * eps_imc_offset) && dia.three_d) {
+  } else if (lowz && dia.three_d) {
     // lower z-face
 
     // vz should be non-negative
@@ -367,12 +397,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vz, dia.vx, dia.vy);
       // set particle z position slightly above face
-      dia.z = dia.zl - eps_imc_offset * dz;
+      dia.z = dia.zl - eps_ddmc_offset * dz;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.z, dia.zu, dz, 2.5 * eps_imc_offset) && dia.three_d) {
+  } else if (higz && dia.three_d) {
     // upper z-face
 
     // vz should be non-positive
@@ -384,7 +414,7 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vz, dia.vx, dia.vy);
       // set particle z position slightly above face
-      dia.z = dia.zu + eps_imc_offset * dz;
+      dia.z = dia.zu + eps_ddmc_offset * dz;
       // set rejection indicator
       is_rejected = true;
     }

--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -48,9 +48,9 @@ struct tran_step_args {
   const Real &aa;      // absorption opacity (1/length)
   const Real &ss;      // scattering opacity (1/length)
   const Real &vv;      // particle speed (should be c)
-  Real &vx;      // particle x/X1-direction speed
-  Real &vy;      // particle y/X2-direction speed
-  Real &vz;      // particle z/X3-direction speed
+  Real &vx;            // particle x/X1-direction speed
+  Real &vy;            // particle y/X2-direction speed
+  Real &vz;            // particle z/X3-direction speed
   const Real &dx_push; // minimum spatial cell dimension
   const bool &multi_d; // 2D or 3D
   const bool &three_d; // 3D
@@ -141,13 +141,6 @@ void ptcl_transport_step(tran_step_args tra) {
   const Real dt_push =
       ((tra.is_absorbed) ? dx_abs : ((tra.is_scattered) ? dx_sc : dx_push)) / tra.vv;
 
-  if (!(dt_push > 0.0) || !(dx_push > 0.0)) {
-    std::cout << "dt_push = " << dt_push << std::endl;
-    std::cout << "dx_push = " << dx_push << std::endl;
-  }
-  PARTHENON_REQUIRE(dt_push > 0.0, "IMC: dt_push <= 0.0");
-  PARTHENON_REQUIRE(dx_push > 0.0, "IMC: dx_push <= 0.0");
-
   // push
   tra.t += dt_push;
   tra.x += tra.vx * dt_push;
@@ -196,8 +189,6 @@ void ptcl_ddmc_step(ddmc_step_args dia) {
 
   // update particle time
   const Real dt_push = std::min(dt_ddmc, dt_end);
-
-  PARTHENON_REQUIRE(dt_push > 0.0, "DDMC: dt_push <= 0.0");
 
   dia.t += dt_push;
 
@@ -428,34 +419,60 @@ void ptcl_ddmc_to_imc(tran_step_args tra) {
     // sample spatial coordinate and velocity
     if (fuzzy_equal(tra.x, tra.xl + resf * eps_ddmc_offset * dx, dx, eps)) {
       // sample y and z
+      tra.y = tra.yl + tra.rng_gen.drand() * resf * dy;
+      tra.z = tra.zl + tra.rng_gen.drand() * resf * dz;
       // sample direction
       sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vx, tra.vy, tra.vz);
+      // break loop
       res_valid = true;
+      break;
     } else if (fuzzy_equal(tra.x, tra.xu - resf * eps_ddmc_offset * dx, dx, eps)) {
       // sample y and z
+      tra.y = tra.yl + tra.rng_gen.drand() * resf * dy;
+      tra.z = tra.zl + tra.rng_gen.drand() * resf * dz;
       // sample direction
       sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vx, tra.vy, tra.vz);
+      // break loop
       res_valid = true;
-    } else if (fuzzy_equal(tra.y, tra.yl + resf * eps_ddmc_offset * dy, dy, eps) && tra.multi_d) {
+      break;
+    } else if (fuzzy_equal(tra.y, tra.yl + resf * eps_ddmc_offset * dy, dy, eps) &&
+               tra.multi_d) {
       // sample x and z
+      tra.x = tra.xl + tra.rng_gen.drand() * resf * dx;
+      tra.z = tra.zl + tra.rng_gen.drand() * resf * dz;
       // sample direction
       sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vy, tra.vz, tra.vx);
       res_valid = true;
-    } else if (fuzzy_equal(tra.y, tra.yu - resf * eps_ddmc_offset * dy, dy, eps) && tra.multi_d) {
+    } else if (fuzzy_equal(tra.y, tra.yu - resf * eps_ddmc_offset * dy, dy, eps) &&
+               tra.multi_d) {
       // sample x and z
+      tra.x = tra.xl + tra.rng_gen.drand() * resf * dx;
+      tra.z = tra.zl + tra.rng_gen.drand() * resf * dz;
       // sample direction
       sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vy, tra.vz, tra.vx);
+      // break loop
       res_valid = true;
-    } else if (fuzzy_equal(tra.z, tra.zl + resf * eps_ddmc_offset * dz, dz, eps) && tra.three_d) {
+      break;
+    } else if (fuzzy_equal(tra.z, tra.zl + resf * eps_ddmc_offset * dz, dz, eps) &&
+               tra.three_d) {
       // sample x and y
+      tra.x = tra.xl + tra.rng_gen.drand() * resf * dx;
+      tra.y = tra.yl + tra.rng_gen.drand() * resf * dy;
       // sample direction
       sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vz, tra.vx, tra.vy);
+      // break loop
       res_valid = true;
-    } else if (fuzzy_equal(tra.z, tra.zu + resf * eps_ddmc_offset * dz, dz, eps) && tra.three_d) {
+      break;
+    } else if (fuzzy_equal(tra.z, tra.zu - resf * eps_ddmc_offset * dz, dz, eps) &&
+               tra.three_d) {
       // sample x and y
+      tra.x = tra.xl + tra.rng_gen.drand() * resf * dx;
+      tra.y = tra.yl + tra.rng_gen.drand() * resf * dy;
       // sample direction
       sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vz, tra.vx, tra.vy);
+      // break loop
       res_valid = true;
+      break;
     }
   }
   PARTHENON_REQUIRE(res_valid, "Invalid transition from DDMC to IMC.");

--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -48,9 +48,9 @@ struct tran_step_args {
   const Real &aa;      // absorption opacity (1/length)
   const Real &ss;      // scattering opacity (1/length)
   const Real &vv;      // particle speed (should be c)
-  const Real &vx;      // particle x/X1-direction speed
-  const Real &vy;      // particle y/X2-direction speed
-  const Real &vz;      // particle z/X3-direction speed
+  Real &vx;      // particle x/X1-direction speed
+  Real &vy;      // particle y/X2-direction speed
+  Real &vz;      // particle z/X3-direction speed
   const Real &dx_push; // minimum spatial cell dimension
   const bool &multi_d; // 2D or 3D
   const bool &three_d; // 3D
@@ -141,6 +141,13 @@ void ptcl_transport_step(tran_step_args tra) {
   const Real dt_push =
       ((tra.is_absorbed) ? dx_abs : ((tra.is_scattered) ? dx_sc : dx_push)) / tra.vv;
 
+  if (!(dt_push > 0.0) || !(dx_push > 0.0)) {
+    std::cout << "dt_push = " << dt_push << std::endl;
+    std::cout << "dx_push = " << dx_push << std::endl;
+  }
+  PARTHENON_REQUIRE(dt_push > 0.0, "IMC: dt_push <= 0.0");
+  PARTHENON_REQUIRE(dx_push > 0.0, "IMC: dx_push <= 0.0");
+
   // push
   tra.t += dt_push;
   tra.x += tra.vx * dt_push;
@@ -189,6 +196,9 @@ void ptcl_ddmc_step(ddmc_step_args dia) {
 
   // update particle time
   const Real dt_push = std::min(dt_ddmc, dt_end);
+
+  PARTHENON_REQUIRE(dt_push > 0.0, "DDMC: dt_push <= 0.0");
+
   dia.t += dt_push;
 
   if (is_ddmc_event) {
@@ -395,6 +405,60 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
     dia.y = 0.5 * (dia.yl + dia.yu);
     dia.z = 0.5 * (dia.zl + dia.zu);
   }
+}
+
+KOKKOS_FORCEINLINE_FUNCTION
+void ptcl_ddmc_to_imc(tran_step_args tra) {
+
+  // set tolerance for checking particle coordinate
+  constexpr Real eps = parthenon::robust::EPS();
+
+  // cell dimensions
+  const Real dx = tra.xu - tra.xl;
+  const Real dy = tra.yu - tra.yl;
+  const Real dz = tra.zu - tra.zl;
+
+  // two possibilities here
+  bool res_valid = false;
+
+  for (int r = 0; r < 2; ++r) {
+
+    const Real resf = 1.0 / static_cast<Real>(r + 1);
+
+    // sample spatial coordinate and velocity
+    if (fuzzy_equal(tra.x, tra.xl + resf * eps_ddmc_offset * dx, dx, eps)) {
+      // sample y and z
+      // sample direction
+      sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vx, tra.vy, tra.vz);
+      res_valid = true;
+    } else if (fuzzy_equal(tra.x, tra.xu - resf * eps_ddmc_offset * dx, dx, eps)) {
+      // sample y and z
+      // sample direction
+      sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vx, tra.vy, tra.vz);
+      res_valid = true;
+    } else if (fuzzy_equal(tra.y, tra.yl + resf * eps_ddmc_offset * dy, dy, eps) && tra.multi_d) {
+      // sample x and z
+      // sample direction
+      sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vy, tra.vz, tra.vx);
+      res_valid = true;
+    } else if (fuzzy_equal(tra.y, tra.yu - resf * eps_ddmc_offset * dy, dy, eps) && tra.multi_d) {
+      // sample x and z
+      // sample direction
+      sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vy, tra.vz, tra.vx);
+      res_valid = true;
+    } else if (fuzzy_equal(tra.z, tra.zl + resf * eps_ddmc_offset * dz, dz, eps) && tra.three_d) {
+      // sample x and y
+      // sample direction
+      sample_face_iso_dir(tra.vv, tra.rng_gen, tra.vz, tra.vx, tra.vy);
+      res_valid = true;
+    } else if (fuzzy_equal(tra.z, tra.zu + resf * eps_ddmc_offset * dz, dz, eps) && tra.three_d) {
+      // sample x and y
+      // sample direction
+      sample_face_iso_dir(-tra.vv, tra.rng_gen, tra.vz, tra.vx, tra.vy);
+      res_valid = true;
+    }
+  }
+  PARTHENON_REQUIRE(res_valid, "Invalid transition from DDMC to IMC.");
 }
 
 } // namespace jaybenne


### PR DESCRIPTION
## Background

* A DDMC block transition issue was caught during ongoing testing with the large shearing box problem.
* Also, mitigate apparent near-hangs with DDMC resulting from misapplication of `ptcl_ddmc_albedo`.

## Description of Changes

+ Check for DDMC block-transition 0-velocity indicator in IMC cell.
+ Use `ptcl_ddmc_to_imc` function to resample position and direction.
+ Modify if-checks in `ptcl_ddmc_albedo` to avoid application to particles with invalid direction.
+ Restrict volume source particle sampling to a tolerance inside cell that avoids false application of `ptcl_ddmc_albedo`
+ Force particles to slightly past end of time step when within a tolerance of the end (IMC) or if census is sampled (DDMC).
+ (Also) update ~and activate~ swarm defrag task.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

