### PR TITLE
[BugFix] Compiling on Chicoma gpus

### DIFF
--- a/src/jaybenne/sample_ddmc_bface.cpp
+++ b/src/jaybenne/sample_ddmc_bface.cpp
@@ -150,16 +150,16 @@ TaskStatus SampleDDMCBlockFace(MeshData<Real> *md) {
               const Real y_j = coords.Xc<parthenon::X2DIR>(jp) - 0.5 * dy_j;
 
               // check particle proximity to block faces
-              // if DDMC moves particle eps_ddmc_offset coarse cell dx then
-              // 2*eps_ddmc_offset current block cell dx
+              // if DDMC moves particle eps_ddmc_offset() coarse cell dx then
+              // 2*eps_ddmc_offset() current block cell dx
               const bool at_block_x_min = fuzzy_equal(
-                  x, swarm_d.x_min_ + 2.0 * eps_ddmc_offset * dx_i, dx_i, eps);
+                  x, swarm_d.x_min_ + 2.0 * eps_ddmc_offset() * dx_i, dx_i, eps);
               const bool at_block_x_max = fuzzy_equal(
-                  x, swarm_d.x_max_ - 2.0 * eps_ddmc_offset * dx_i, dx_i, eps);
+                  x, swarm_d.x_max_ - 2.0 * eps_ddmc_offset() * dx_i, dx_i, eps);
               const bool at_block_y_min = fuzzy_equal(
-                  y, swarm_d.y_min_ + 2.0 * eps_ddmc_offset * dy_j, dy_j, eps);
+                  y, swarm_d.y_min_ + 2.0 * eps_ddmc_offset() * dy_j, dy_j, eps);
               const bool at_block_y_max = fuzzy_equal(
-                  y, swarm_d.y_max_ - 2.0 * eps_ddmc_offset * dy_j, dy_j, eps);
+                  y, swarm_d.y_max_ - 2.0 * eps_ddmc_offset() * dy_j, dy_j, eps);
 
               if (at_block_x_min || at_block_x_max) {
                 // check at high or low x block face
@@ -269,20 +269,20 @@ TaskStatus SampleDDMCBlockFace(MeshData<Real> *md) {
               const Real z_k = coords.Xc<parthenon::X3DIR>(kp) - 0.5 * dz_k;
 
               // check particle proximity to block faces
-              // if DDMC moves particle eps_ddmc_offset coarse cell dx then
-              // 2*eps_ddmc_offset current block cell dx
+              // if DDMC moves particle eps_ddmc_offset() coarse cell dx then
+              // 2*eps_ddmc_offset() current block cell dx
               const bool at_block_x_min = fuzzy_equal(
-                  x, swarm_d.x_min_ + 2.0 * eps_ddmc_offset * dx_i, dx_i, eps);
+                  x, swarm_d.x_min_ + 2.0 * eps_ddmc_offset() * dx_i, dx_i, eps);
               const bool at_block_x_max = fuzzy_equal(
-                  x, swarm_d.x_max_ - 2.0 * eps_ddmc_offset * dx_i, dx_i, eps);
+                  x, swarm_d.x_max_ - 2.0 * eps_ddmc_offset() * dx_i, dx_i, eps);
               const bool at_block_y_min = fuzzy_equal(
-                  y, swarm_d.y_min_ + 2.0 * eps_ddmc_offset * dy_j, dy_j, eps);
+                  y, swarm_d.y_min_ + 2.0 * eps_ddmc_offset() * dy_j, dy_j, eps);
               const bool at_block_y_max = fuzzy_equal(
-                  y, swarm_d.y_max_ - 2.0 * eps_ddmc_offset * dy_j, dy_j, eps);
+                  y, swarm_d.y_max_ - 2.0 * eps_ddmc_offset() * dy_j, dy_j, eps);
               const bool at_block_z_min = fuzzy_equal(
-                  z, swarm_d.z_min_ + 2.0 * eps_ddmc_offset * dz_k, dz_k, eps);
+                  z, swarm_d.z_min_ + 2.0 * eps_ddmc_offset() * dz_k, dz_k, eps);
               const bool at_block_z_max = fuzzy_equal(
-                  z, swarm_d.z_max_ - 2.0 * eps_ddmc_offset * dz_k, dz_k, eps);
+                  z, swarm_d.z_max_ - 2.0 * eps_ddmc_offset() * dz_k, dz_k, eps);
 
               if (at_block_x_min || at_block_x_max) {
                 // check at high or low x block face

--- a/src/jaybenne/transport_utils.hpp
+++ b/src/jaybenne/transport_utils.hpp
@@ -21,8 +21,11 @@ namespace jaybenne {
 
 // position displacements into next cell, for IMC and DDMC
 // TODO(@pdmllen): how to best set prefactor?
-constexpr Real eps_imc_offset = 1.0e6 * parthenon::robust::EPS();
-constexpr Real eps_ddmc_offset = 1.0e8 * parthenon::robust::EPS();
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr Real eps_imc_offset() { return 1.0e6 * parthenon::robust::EPS(); }
+
+KOKKOS_FORCEINLINE_FUNCTION
+constexpr Real eps_ddmc_offset() { return 1.0e8 * parthenon::robust::EPS(); }
 
 KOKKOS_FORCEINLINE_FUNCTION
 void sample_face_iso_dir(const Real vv, RngGen &rng_gen, Real &v1, Real &v2, Real &v3) {
@@ -149,9 +152,9 @@ void ptcl_transport_step(tran_step_args tra) {
 
   // handle faces
   const bool leave = !(tra.is_absorbed || tra.is_scattered);
-  const Real fdx = eps_imc_offset * (tra.xu - tra.xl);
-  const Real fdy = eps_imc_offset * (tra.yu - tra.yl);
-  const Real fdz = eps_imc_offset * (tra.zu - tra.zl);
+  const Real fdx = eps_imc_offset() * (tra.xu - tra.xl);
+  const Real fdy = eps_imc_offset() * (tra.yu - tra.yl);
+  const Real fdz = eps_imc_offset() * (tra.zu - tra.zl);
   tra.x = (std::abs(tra.x - tra.xl) < fdx && leave) ? tra.xl - fdx : tra.x;
   tra.x = (std::abs(tra.x - tra.xu) < fdx && leave) ? tra.xu + fdx : tra.x;
   tra.y = (tra.multi_d && std::abs(tra.y - tra.yl) < fdy && leave) ? tra.yl - fdy : tra.y;
@@ -167,7 +170,7 @@ void ptcl_ddmc_step(ddmc_step_args dia) {
   const Real rmin = std::numeric_limits<Real>::min();
 
   // calculate cell dimensions
-  const Real eps = eps_ddmc_offset; // move particles eps_ddmc_offset into next cell
+  const Real eps = eps_ddmc_offset(); // move particles eps_ddmc_offset() into next cell
   const Real dx = dia.xu - dia.xl;
   const Real dy = dia.yu - dia.yl;
   const Real dz = dia.zu - dia.zl;
@@ -286,7 +289,7 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
   const Real dz = dia.zu - dia.zl;
 
   // check that coordinate is at cell edge (only possible coming from IMC)
-  if (fuzzy_equal(dia.x, dia.xl, dx, 2.5 * eps_imc_offset)) {
+  if (fuzzy_equal(dia.x, dia.xl, dx, 2.5 * eps_imc_offset())) {
     // lower x-face
 
     // vx should be non-negative
@@ -298,12 +301,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vx, dia.vy, dia.vz);
       // set particle z position slightly above face
-      dia.x = dia.xl - eps_imc_offset * dx;
+      dia.x = dia.xl - eps_imc_offset() * dx;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.x, dia.xu, dx, 2.5 * eps_imc_offset)) {
+  } else if (fuzzy_equal(dia.x, dia.xu, dx, 2.5 * eps_imc_offset())) {
     // upper x-face
 
     // vx should be non-positive
@@ -315,12 +318,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vx, dia.vy, dia.vz);
       // set particle z position slightly above face
-      dia.x = dia.xu + eps_imc_offset * dx;
+      dia.x = dia.xu + eps_imc_offset() * dx;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.y, dia.yl, dy, 2.5 * eps_imc_offset) && dia.multi_d) {
+  } else if (fuzzy_equal(dia.y, dia.yl, dy, 2.5 * eps_imc_offset()) && dia.multi_d) {
     // lower y-face
 
     // vy should be non-negative
@@ -332,12 +335,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vy, dia.vz, dia.vx);
       // set particle y position slightly above face
-      dia.y = dia.yl - eps_imc_offset * dy;
+      dia.y = dia.yl - eps_imc_offset() * dy;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.y, dia.yu, dy, 2.5 * eps_imc_offset) && dia.multi_d) {
+  } else if (fuzzy_equal(dia.y, dia.yu, dy, 2.5 * eps_imc_offset()) && dia.multi_d) {
     // upper y-face
 
     // vy should be non-positive
@@ -349,12 +352,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vy, dia.vz, dia.vx);
       // set particle y position slightly above face
-      dia.y = dia.yu + eps_imc_offset * dy;
+      dia.y = dia.yu + eps_imc_offset() * dy;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.z, dia.zl, dz, 2.5 * eps_imc_offset) && dia.three_d) {
+  } else if (fuzzy_equal(dia.z, dia.zl, dz, 2.5 * eps_imc_offset()) && dia.three_d) {
     // lower z-face
 
     // vz should be non-negative
@@ -366,12 +369,12 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(-dia.vv, dia.rng_gen, dia.vz, dia.vx, dia.vy);
       // set particle z position slightly above face
-      dia.z = dia.zl - eps_imc_offset * dz;
+      dia.z = dia.zl - eps_imc_offset() * dz;
       // set rejection indicator
       is_rejected = true;
     }
 
-  } else if (fuzzy_equal(dia.z, dia.zu, dz, 2.5 * eps_imc_offset) && dia.three_d) {
+  } else if (fuzzy_equal(dia.z, dia.zu, dz, 2.5 * eps_imc_offset()) && dia.three_d) {
     // upper z-face
 
     // vz should be non-positive
@@ -383,7 +386,7 @@ void ptcl_ddmc_albedo(ddmc_step_args dia, bool &is_rejected) {
       // sample direction
       sample_face_iso_dir(dia.vv, dia.rng_gen, dia.vz, dia.vx, dia.vy);
       // set particle z position slightly above face
-      dia.z = dia.zu + eps_imc_offset * dz;
+      dia.z = dia.zu + eps_imc_offset() * dz;
       // set rejection indicator
       is_rejected = true;
     }


### PR DESCRIPTION
## Background

I wasn't able to compile on chicoma gpus because of these lines:

```c++
constexpr Real eps_imc_offset = 1.0e6 * parthenon::robust::EPS();
constexpr Real eps_ddmc_offset = 1.0e8 * parthenon::robust::EPS();
```
The `parthenon::robust::EPS()` functions are not guaranteed to be evaluated at compile time despite being marked `constexpr`. Some compilers just won't do it unfortunately. So these lines needed to be changed to function calls much like `parthenon::robust::EPS()` itself (which is a function call for the very same reason related to `std::numeric_limits`). 

## Description of Changes

- [ ]

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

