### PR TITLE
Allow the minimum number of particles per cell to be a user parameter

### DIFF
--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -194,7 +194,7 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   // Total number of particles
   int num_particles = pin->GetInteger(block_name, "num_particles");
   pkg->AddParam<>("num_particles", num_particles);
-  Real npc_min = pin->GetOrAddReal(block_name, "dnpc_min", 20.0);
+  Real dnpc_min = pin->GetOrAddReal(block_name, "dnpc_min", 20.0);
   PARTHENON_REQUIRE(dnpc_min >= 1.0, "dnpc_min must be at least 1");
   pkg->AddParam<>("dnpc_min", dnpc_min);
   Real dt = pin->GetOrAddReal(block_name, "dt", std::numeric_limits<Real>::max());

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -194,9 +194,9 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   // Total number of particles
   int num_particles = pin->GetInteger(block_name, "num_particles");
   pkg->AddParam<>("num_particles", num_particles);
-  Real npc_min = pin->GetOrAddReal(block_name, "npc_min", 20.0);
-  PARTHENON_REQUIRE(npc_min >= 1.0, "npc_min must be at least 1");
-  pkg->AddParam<>("npc_min", npc_min);
+  Real npc_min = pin->GetOrAddReal(block_name, "dnpc_min", 20.0);
+  PARTHENON_REQUIRE(dnpc_min >= 1.0, "dnpc_min must be at least 1");
+  pkg->AddParam<>("dnpc_min", dnpc_min);
   Real dt = pin->GetOrAddReal(block_name, "dt", std::numeric_limits<Real>::max());
   pkg->AddParam<>("dt", dt);
 

--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -194,6 +194,9 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
   // Total number of particles
   int num_particles = pin->GetInteger(block_name, "num_particles");
   pkg->AddParam<>("num_particles", num_particles);
+  Real npc_min = pin->GetOrAddReal(block_name, "npc_min", 20.0);
+  PARTHENON_REQUIRE(npc_min >= 1.0, "npc_min must be at least 1");
+  pkg->AddParam<>("npc_min", npc_min);
   Real dt = pin->GetOrAddReal(block_name, "dt", std::numeric_limits<Real>::max());
   pkg->AddParam<>("dt", dt);
 

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -64,6 +64,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   // Extract params
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
   const int &num_particles = jb_pkg->template Param<int>("num_particles");
+  const Real &npc_min = jb_pkg->template Param<Real>("npc_min");
   const Real &vv = jb_pkg->template Param<Real>("speed_of_light");
   const Real &sb = jb_pkg->template Param<Real>("stefan_boltzmann");
 
@@ -161,7 +162,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
               // introducing supplementary functions/tasks that set these, or even
               // giving downstream codes the opportunity to set these themselves...
               snpc = npc;
-              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), 20.0);
+              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), npc_min);
               sewpc = erad / dnum;
               ntot += static_cast<int>(dnum);
             },

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -64,7 +64,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   // Extract params
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
   const int &num_particles = jb_pkg->template Param<int>("num_particles");
-  const Real &npc_min = jb_pkg->template Param<Real>("npc_min");
+  const Real &dnpc_min = jb_pkg->template Param<Real>("dnpc_min");
   const Real &vv = jb_pkg->template Param<Real>("speed_of_light");
   const Real &sb = jb_pkg->template Param<Real>("stefan_boltzmann");
 
@@ -162,7 +162,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
               // introducing supplementary functions/tasks that set these, or even
               // giving downstream codes the opportunity to set these themselves...
               snpc = npc;
-              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), npc_min);
+              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), dnpc_min);
               sewpc = erad / dnum;
               ntot += static_cast<int>(dnum);
             },


### PR DESCRIPTION
## Background

When doing a scaling study, it was useful to set this number instead of `num_particles`.

## Description of Changes

- [ ]

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

