### PR TITLE
Add diagnostic level stdout for total active particle population.

### DIFF
--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -17,6 +17,7 @@
 // Jaybenne includes
 #include "jaybenne.hpp"
 #include "jaybenne_utils.hpp"
+#include <utils/robust.hpp>
 
 namespace jaybenne {
 
@@ -65,8 +66,15 @@ TaskStatus MeshReceive(MeshData<Real> *md) {
 //! \brief Construct the collection of tasks that contribute to a complete radiation cycle
 //!        from t to t + dt, including setting up derived quantities, sourcing particles,
 //!        transporting particles, and communicating particles.
-TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
+TaskCollection RadiationStep(Mesh *pmesh, const SimTime &tm, const Real dt) {
   namespace fj = field::jaybenne;
+
+  // short-cuts
+  const Real &t_start = tm.time;
+  const int &ncycle = tm.ncycle;
+  const int &ncycle_out = tm.ncycle_out;
+  PARTHENON_REQUIRE(fuzzy_equal(tm.dt, dt, dt, parthenon::robust::EPS()),
+                    "Integrator dt (RadiationStep arg) must equal SimTime dt");
 
   auto &jb_pkg = pmesh->packages.Get("jaybenne");
   const auto &max_transport_iterations =
@@ -163,7 +171,8 @@ TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt) {
     auto update_fluid = tl.AddTask(eval_rad, jaybenne::UpdateFluid, base.get());
 
     // Control particle population
-    auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get());
+    auto control_pop = tl.AddTask(update_fluid, jaybenne::ControlPopulation, base.get(),
+                                  ncycle, ncycle_out);
 
     // TODO: Defrag particles? Verify parth swarm defrag mechanics before uncommenting
     // auto defrag_pop = tl.AddTask(control_pop, jaybenne::DefragParticles, base.get());
@@ -190,6 +199,12 @@ std::shared_ptr<StateDescriptor>
 Initialize_impl(ParameterInput *pin, EOS &eos,
                 singularity::RuntimePhysicalConstants units, std::string block_name) {
   auto pkg = std::make_shared<StateDescriptor>("jaybenne");
+
+  // Diagnostics verbosity
+  int diagnostic_level = pin->GetOrAddInteger(block_name, "diagnostic_level", 0);
+  pkg->AddParam<>("diagnostic_level", diagnostic_level);
+  PARTHENON_REQUIRE(diagnostic_level >= 0 && diagnostic_level <= 1,
+                    "diagnostic_level is currently restricted to 0 or 1");
 
   // Total number of particles
   int num_particles = pin->GetInteger(block_name, "num_particles");

--- a/src/jaybenne/jaybenne.hpp
+++ b/src/jaybenne/jaybenne.hpp
@@ -84,10 +84,10 @@ TaskStatus UpdateDerivedTransportFields(MeshData<Real> *md, const Real dt);
 template <typename T>
 TaskStatus EvaluateRadiationEnergy(T *md);
 TaskStatus UpdateFluid(MeshData<Real> *md);
-TaskStatus ControlPopulation(MeshData<Real> *md);
+TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncycle_out);
 
 // TaskCollection for radiation step
-TaskCollection RadiationStep(Mesh *pmesh, const Real t_start, const Real dt);
+TaskCollection RadiationStep(Mesh *pmesh, const SimTime &tm, const Real dt);
 
 // Functions
 Real EstimateTimestepMesh(MeshData<Real> *md);

--- a/src/jaybenne/jaybenne_utils.hpp
+++ b/src/jaybenne/jaybenne_utils.hpp
@@ -45,20 +45,16 @@ par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int j
 
 template <typename Function, typename U>
 void global_sum_reduce(const int nblocks, const int kl, const int ku, const int jl,
-                       const int ju, const int il, const int iu, const std::string label,
+                       const int ju, const int il, const int iu, const std::string &label,
                        const Function &function, U &globally_reduced) {
   PARTHENON_DEBUG_REQUIRE(std::is_scalar<U>::value,
                           "global_sum_reduce only works on scalars.");
 
   // reduce over local blocks
   U totag = 0;
-  parthenon::par_reduce(
-      parthenon::loop_pattern_mdrange_tag, label, DevExecSpace(), 0, nblocks - 1, kl, ku,
-      jl, ju, il, iu,
-      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, U &tota) {
-        function(b, k, j, i, tota);
-      },
-      Kokkos::Sum<U>(totag));
+  parthenon::par_reduce(parthenon::loop_pattern_mdrange_tag, "tstlabel", DevExecSpace(),
+                        0, nblocks - 1, kl, ku, jl, ju, il, iu, function,
+                        Kokkos::Sum<U>(totag));
   Kokkos::fence();
 
   // reduce over MPI ranks

--- a/src/jaybenne/jaybenne_utils.hpp
+++ b/src/jaybenne/jaybenne_utils.hpp
@@ -17,6 +17,8 @@
 #include <parthenon/driver.hpp>
 #include <parthenon/package.hpp>
 
+namespace jaybenne {
+
 template <typename Function, typename T>
 KOKKOS_FORCEINLINE_FUNCTION void
 par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int jl,
@@ -41,11 +43,40 @@ par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int j
       reduction);
 }
 
+template <typename Function, typename U>
+void global_sum_reduce(const int nblocks, const int kl, const int ku, const int jl,
+                       const int ju, const int il, const int iu, const std::string label,
+                       const Function &function, U &globally_reduced) {
+  PARTHENON_DEBUG_REQUIRE(std::is_scalar<U>::value,
+                          "global_sum_reduce only works on scalars.");
+
+  // reduce over local blocks
+  U totag = 0;
+  parthenon::par_reduce(
+      parthenon::loop_pattern_mdrange_tag, label, DevExecSpace(), 0, nblocks - 1, kl, ku,
+      jl, ju, il, iu,
+      KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, U &tota) {
+        function(b, k, j, i, tota);
+      },
+      Kokkos::Sum<U>(totag));
+  Kokkos::fence();
+
+  // reduce over MPI ranks
+#ifdef MPI_PARALLEL
+  MPI_Reduce(&totag, &globally_reduced, 1, MPITypeMap<U>::type(), MPI_SUM, 0,
+             MPI_COMM_WORLD);
+#else
+  globally_reduced = totag;
+#endif
+}
+
 KOKKOS_FORCEINLINE_FUNCTION bool fuzzy_equal(const Real &a, const Real &b, const Real &c,
                                              const Real &eps) {
   PARTHENON_DEBUG_REQUIRE(c > 0.0, "c input must be positive");
   // c input makes user decide metric
   return std::abs(a - b) < c * eps;
 }
+
+} // namespace jaybenne
 
 #endif // JAYBENNE_JAYBENNE_UTILS_HPP_

--- a/src/jaybenne/jaybenne_utils.hpp
+++ b/src/jaybenne/jaybenne_utils.hpp
@@ -43,18 +43,18 @@ par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int j
       reduction);
 }
 
-template <typename Function, typename U>
-void global_sum_reduce(const int nblocks, const int kl, const int ku, const int jl,
-                       const int ju, const int il, const int iu, const std::string &label,
-                       const Function &function, U &globally_reduced) {
+template <typename ExecSpace, typename Function, typename U>
+void global_sum_reduce(const std::string &label, const ExecSpace &space,
+                       const int nblocks, const int kl, const int ku, const int jl,
+                       const int ju, const int il, const int iu, const Function &function,
+                       U &globally_reduced) {
   PARTHENON_DEBUG_REQUIRE(std::is_scalar<U>::value,
                           "global_sum_reduce only works on scalars.");
 
   // reduce over local blocks
   U totag = 0;
-  parthenon::par_reduce(parthenon::loop_pattern_mdrange_tag, "tstlabel", DevExecSpace(),
-                        0, nblocks - 1, kl, ku, jl, ju, il, iu, function,
-                        Kokkos::Sum<U>(totag));
+  parthenon::par_reduce(parthenon::loop_pattern_mdrange_tag, label, space, 0, nblocks - 1,
+                        kl, ku, jl, ju, il, iu, function, Kokkos::Sum<U>(totag));
   Kokkos::fence();
 
   // reduce over MPI ranks

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -94,7 +94,8 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
     global_sum_reduce(
         nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         "ControlPopulation::report-tot-active-1",
-        [&](const int &b, const int &k, const int &j, const int &i, Real &tota) {
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
+                      Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
         },
         num_tot_active_old);
@@ -179,7 +180,8 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
     global_sum_reduce(
         nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
         "ControlPopulation::report-tot-active-2",
-        [&](const int &b, const int &k, const int &j, const int &i, Real &tota) {
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
+                      Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
         },
         num_tot_active);

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -92,8 +92,8 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
   if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
     Real num_tot_active_old = 0.0;
     global_sum_reduce(
-        nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        "ControlPopulation::report-tot-active-1",
+        "ControlPopulation::report-tot-active-1", DevExecSpace(), nblocks, kb.s, kb.e,
+        jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
                       Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
@@ -178,8 +178,8 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
   if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
     Real num_tot_active = 0.0;
     global_sum_reduce(
-        nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        "ControlPopulation::report-tot-active-2",
+        "ControlPopulation::report-tot-active-2", DevExecSpace(), nblocks, kb.s, kb.e,
+        jb.s, jb.e, ib.s, ib.e,
         KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
                       Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -24,7 +24,7 @@ namespace jaybenne {
 //! particles. The expectation value is then the number of source particles: N_rm ~ P_rm *
 //! N_act = (1 - N_src / N_act) * N_act = N_act - N_src The remaining particles then each
 //! have their energy weight renormalized.
-TaskStatus ControlPopulation(MeshData<Real> *md) {
+TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncycle_out) {
   namespace fj = field::jaybenne;
   namespace ph = particle::photons;
 
@@ -32,6 +32,7 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
   auto &resolved_pkgs = pm->resolved_packages;
   auto &jb_pkg = pm->packages.Get("jaybenne");
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
+  const auto &diagnostic_level = jb_pkg->template Param<int>("diagnostic_level");
 
   // Create SparsePack
   static auto desc =
@@ -84,6 +85,34 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
           Kokkos::atomic_add(&actnum, 1.0);
         }
       });
+
+  //--------------------------------------------------------------------------------------
+  // print total number of active particles at a certain diagnostic level
+  if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
+    Real totag = 0.0;
+    parthenon::par_reduce(
+        parthenon::loop_pattern_mdrange_tag, "ControlPopulation::report-tot-active-1",
+        DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &tota) {
+          tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
+        },
+        Kokkos::Sum<Real>(totag));
+
+    Real num_tot_active_old;
+
+    // reduce over MPI ranks
+#ifdef MPI_PARALLEL
+    MPI_Reduce(&totag, &num_tot_active_old, 1, MPI_PARTHENON_REAL, MPI_SUM, 0,
+               MPI_COMM_WORLD);
+#else
+    num_tot_active_old = totag;
+#endif
+
+    // print total on rank 0
+    if (Globals::my_rank == 0) {
+      std::cout << "Post-IMC # active particles: " << num_tot_active_old << std::endl;
+    }
+  }
 
   //--------------------------------------------------------------------------------------
   // sample probability to mark particle for removal
@@ -151,6 +180,35 @@ TaskStatus ControlPopulation(MeshData<Real> *md) {
           Kokkos::atomic_add(&actnum, 1.0);
         }
       });
+
+  //--------------------------------------------------------------------------------------
+  // print total number of active particles at a certain diagnostic level
+  if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
+    // reduce over blocks and cells
+    Real totag = 0.0;
+    parthenon::par_reduce(
+        parthenon::loop_pattern_mdrange_tag, "ControlPopulation::report-tot-active-2",
+        DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &tota) {
+          tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
+        },
+        Kokkos::Sum<Real>(totag));
+
+    Real num_tot_active;
+
+    // reduce over MPI ranks
+#ifdef MPI_PARALLEL
+    MPI_Reduce(&totag, &num_tot_active, 1, MPI_PARTHENON_REAL, MPI_SUM, 0,
+               MPI_COMM_WORLD);
+#else
+    num_tot_active = totag;
+#endif
+
+    // print total on rank 0
+    if (Globals::my_rank == 0) {
+      std::cout << "Post-PopCon # active particles: " << num_tot_active << std::endl;
+    }
+  }
 
   //--------------------------------------------------------------------------------------
   // renormalize surviving particle energy weights, to conserve energy

--- a/src/jaybenne/population_control.cpp
+++ b/src/jaybenne/population_control.cpp
@@ -13,6 +13,7 @@
 
 // Jaybenne includes
 #include "jaybenne.hpp"
+#include "jaybenne_utils.hpp"
 
 namespace jaybenne {
 
@@ -89,24 +90,14 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
   //--------------------------------------------------------------------------------------
   // print total number of active particles at a certain diagnostic level
   if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
-    Real totag = 0.0;
-    parthenon::par_reduce(
-        parthenon::loop_pattern_mdrange_tag, "ControlPopulation::report-tot-active-1",
-        DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &tota) {
+    Real num_tot_active_old = 0.0;
+    global_sum_reduce(
+        nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        "ControlPopulation::report-tot-active-1",
+        [&](const int &b, const int &k, const int &j, const int &i, Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
         },
-        Kokkos::Sum<Real>(totag));
-
-    Real num_tot_active_old;
-
-    // reduce over MPI ranks
-#ifdef MPI_PARALLEL
-    MPI_Reduce(&totag, &num_tot_active_old, 1, MPI_PARTHENON_REAL, MPI_SUM, 0,
-               MPI_COMM_WORLD);
-#else
-    num_tot_active_old = totag;
-#endif
+        num_tot_active_old);
 
     // print total on rank 0
     if (Globals::my_rank == 0) {
@@ -184,25 +175,14 @@ TaskStatus ControlPopulation(MeshData<Real> *md, const int ncycle, const int ncy
   //--------------------------------------------------------------------------------------
   // print total number of active particles at a certain diagnostic level
   if (diagnostic_level >= 1 && ncycle % ncycle_out == 0) {
-    // reduce over blocks and cells
-    Real totag = 0.0;
-    parthenon::par_reduce(
-        parthenon::loop_pattern_mdrange_tag, "ControlPopulation::report-tot-active-2",
-        DevExecSpace(), 0, nblocks - 1, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-        KOKKOS_LAMBDA(const int b, const int k, const int j, const int i, Real &tota) {
+    Real num_tot_active = 0.0;
+    global_sum_reduce(
+        nblocks, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+        "ControlPopulation::report-tot-active-2",
+        [&](const int &b, const int &k, const int &j, const int &i, Real &tota) {
           tota += vmesh(b, fj::active_num_per_cell(), k, j, i);
         },
-        Kokkos::Sum<Real>(totag));
-
-    Real num_tot_active;
-
-    // reduce over MPI ranks
-#ifdef MPI_PARALLEL
-    MPI_Reduce(&totag, &num_tot_active, 1, MPI_PARTHENON_REAL, MPI_SUM, 0,
-               MPI_COMM_WORLD);
-#else
-    num_tot_active = totag;
-#endif
+        num_tot_active);
 
     // print total on rank 0
     if (Globals::my_rank == 0) {

--- a/src/mcblock/mcblock_driver.cpp
+++ b/src/mcblock/mcblock_driver.cpp
@@ -43,7 +43,7 @@ TaskListStatus McblockDriver::Step() {
   const Real &dt = integrator->dt;
 
   // One cycle of radiation transport
-  auto status = jaybenne::RadiationStep(pmesh, this->tm.time, integrator->dt).Execute();
+  auto status = jaybenne::RadiationStep(pmesh, tm, dt).Execute();
   if (status != TaskListStatus::complete) return status;
 
   // compute new dt


### PR DESCRIPTION
## Background

* Diagnostic printout for scalar totals can be a useful gauge of correct simulation behavior.

## Description of Changes

+ Include SimTime object in `RadiationStep` task collection, to get ncycle[_out].
+ Add MPI_Reduce to rank 0 of sum of particle number over cells.
+ Add diagnostic_level user input, restricted to 0 or 1 (for now).
+ Update Parthenon submodule to same version currently set in `Artemis`.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

