### PR TITLE
Add emission temperature threshold for sourcing particles per cell.

### DIFF
--- a/src/jaybenne/jaybenne.cpp
+++ b/src/jaybenne/jaybenne.cpp
@@ -264,6 +264,8 @@ Initialize_impl(ParameterInput *pin, EOS &eos,
     PARTHENON_FAIL("Only uniform or energy source strategies supported!");
   }
   pkg->AddParam<>("source_strategy", source_strategy);
+  Real emit_temp_threshold = pin->GetOrAddReal(block_name, "emit_temp_threshold", 0.0);
+  pkg->AddParam<>("emit_temp_threshold", emit_temp_threshold);
 
   // Whether to include emission physics
   const bool do_emission = pin->GetOrAddBoolean(block_name, "do_emission", true);

--- a/src/jaybenne/jaybenne_utils.hpp
+++ b/src/jaybenne/jaybenne_utils.hpp
@@ -47,7 +47,7 @@ template <typename ExecSpace, typename Function, typename U>
 void global_sum_reduce(const std::string &label, const ExecSpace &space,
                        const int nblocks, const int kl, const int ku, const int jl,
                        const int ju, const int il, const int iu, const Function &function,
-                       U &globally_reduced) {
+                       U &globally_reduced, const bool allreduce = false) {
   PARTHENON_INSTRUMENT
   PARTHENON_DEBUG_REQUIRE(std::is_scalar<U>::value,
                           "global_sum_reduce only works on scalars.");
@@ -60,8 +60,13 @@ void global_sum_reduce(const std::string &label, const ExecSpace &space,
 
   // reduce over MPI ranks
 #ifdef MPI_PARALLEL
-  MPI_Reduce(&totag, &globally_reduced, 1, MPITypeMap<U>::type(), MPI_SUM, 0,
-             MPI_COMM_WORLD);
+  if (allreduce) {
+    MPI_Allreduce(&totag, &globally_reduced, 1, MPITypeMap<U>::type(), MPI_SUM,
+                  MPI_COMM_WORLD);
+  } else {
+    MPI_Reduce(&totag, &globally_reduced, 1, MPITypeMap<U>::type(), MPI_SUM, 0,
+               MPI_COMM_WORLD);
+  }
 #else
   globally_reduced = totag;
 #endif

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -94,35 +94,33 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   Real npc = std::floor(static_cast<Real>(num_particles) /
                         (num_cells * md->GetMeshPointer()->nbtotal));
 
-  if constexpr (ST == SourceType::emission) {
-    // adjust particle number per cell up if threshold temperature is used
-    if (emit_temp_th > 0.0) {
-      // count the number of cells above the temperature threshold
-      Real ncell_abv_th = 0.0;
-      global_sum_reduce(
-          "count-emitting-cells", DevExecSpace(), nblocks, kb.s, kb.e, jb.s, jb.e, ib.s,
-          ib.e,
-          KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
-                        Real &totth) {
-            const Real &rho = vmesh(b, fjh::density(), k, j, i);
-            const Real &sie = vmesh(b, fjh::sie(), k, j, i);
-            const Real temp = eos.TemperatureFromDensityInternalEnergy(rho, sie);
-            totth += (temp > emit_temp_th ? 1.0 : 0.0);
-          },
-          ncell_abv_th);
+  // adjust particle number per cell up if threshold temperature is used
+  if (emit_temp_th > 0.0) {
+    // count the number of cells above the temperature threshold
+    Real ncell_abv_th = 0.0;
+    global_sum_reduce(
+        "SourcePhotons::count-emitting-cells", DevExecSpace(), nblocks, kb.s, kb.e, jb.s,
+        jb.e, ib.s, ib.e,
+        KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
+                      Real &totth) {
+          const Real &rho = vmesh(b, fjh::density(), k, j, i);
+          const Real &sie = vmesh(b, fjh::sie(), k, j, i);
+          const Real temp = eos.TemperatureFromDensityInternalEnergy(rho, sie);
+          totth += (temp > emit_temp_th ? 1.0 : 0.0);
+        },
+        ncell_abv_th);
 
-      PARTHENON_REQUIRE(ncell_abv_th > 0.0,
-                        "emission source but all cells below threshold temperature!");
+    PARTHENON_REQUIRE(ncell_abv_th > 0.0,
+                      "emission source but all cells below threshold temperature!");
 
-      // calculate scaling factor on number per cell
-      const Real npratio =
-          static_cast<Real>(num_cells * md->GetMeshPointer()->nbtotal) / ncell_abv_th;
-      PARTHENON_DEBUG_REQUIRE(npratio >= 1.0,
-                              "more emitting cells than total cells in problem!");
+    // calculate scaling factor on number per cell
+    const Real npratio =
+        static_cast<Real>(num_cells * md->GetMeshPointer()->nbtotal) / ncell_abv_th;
+    PARTHENON_DEBUG_REQUIRE(npratio >= 1.0,
+                            "more emitting cells than total cells in problem!");
 
-      // upgrade number of particles per (emitting) cell
-      npc = std::floor(npc * npratio);
-    }
+    // upgrade number of particles per (emitting) cell
+    npc = std::floor(npc * npratio);
   }
 
   ParArray1D<int> nparticles("# particles per block", nblocks);

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -66,6 +66,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   auto &rng_pool = jb_pkg->template Param<RngPool>("rng_pool");
   const int &num_particles = jb_pkg->template Param<int>("num_particles");
   const Real &dnpc_min = jb_pkg->template Param<Real>("dnpc_min");
+  const Real &emit_temp_th = jb_pkg->template Param<Real>("emit_temp_threshold");
   const Real &vv = jb_pkg->template Param<Real>("speed_of_light");
   const Real &sb = jb_pkg->template Param<Real>("stefan_boltzmann");
 
@@ -89,8 +90,40 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
   const int nx2 = jb.e - jb.s + 1;
   const int nx3 = kb.e - kb.s + 1;
   const int num_cells = nx1 * nx2 * nx3;
-  const Real npc = std::floor(static_cast<Real>(num_particles) /
-                              (num_cells * md->GetMeshPointer()->nbtotal));
+
+  Real npc = std::floor(static_cast<Real>(num_particles) /
+                        (num_cells * md->GetMeshPointer()->nbtotal));
+
+  if constexpr (ST == SourceType::emission) {
+    // adjust particle number per cell up if threshold temperature is used
+    if (emit_temp_th > 0.0) {
+      // count the number of cells above the temperature threshold
+      Real ncell_abv_th = 0.0;
+      global_sum_reduce(
+          "count-emitting-cells", DevExecSpace(), nblocks, kb.s, kb.e, jb.s, jb.e, ib.s,
+          ib.e,
+          KOKKOS_LAMBDA(const int &b, const int &k, const int &j, const int &i,
+                        Real &totth) {
+            const Real &rho = vmesh(b, fjh::density(), k, j, i);
+            const Real &sie = vmesh(b, fjh::sie(), k, j, i);
+            const Real temp = eos.TemperatureFromDensityInternalEnergy(rho, sie);
+            totth += (temp > emit_temp_th ? 1.0 : 0.0);
+          },
+          ncell_abv_th);
+
+      PARTHENON_REQUIRE(ncell_abv_th > 0.0,
+                        "emission source but all cells below threshold temperature!");
+
+      // calculate scaling factor on number per cell
+      const Real npratio =
+          static_cast<Real>(num_cells * md->GetMeshPointer()->nbtotal) / ncell_abv_th;
+      PARTHENON_DEBUG_REQUIRE(npratio >= 1.0,
+                              "more emitting cells than total cells in problem!");
+
+      // upgrade number of particles per (emitting) cell
+      npc = std::floor(npc * npratio);
+    }
+  }
 
   ParArray1D<int> nparticles("# particles per block", nblocks);
   ParArray2D<int> prefix_sum("prefix sums per block", nblocks, num_cells);
@@ -162,10 +195,16 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
               // NOTE(PDM): We hardcode snpc and sewpc below, but we could imagine
               // introducing supplementary functions/tasks that set these, or even
               // giving downstream codes the opportunity to set these themselves...
-              snpc = npc;
-              dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), dnpc_min);
-              sewpc = erad / dnum;
-              ntot += static_cast<int>(dnum);
+              if (temp > emit_temp_th) {
+                snpc = npc;
+                dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), dnpc_min);
+                sewpc = erad / dnum;
+                ntot += static_cast<int>(dnum);
+              } else {
+                snpc = 0.0;
+                dnum = 0.0;
+                sewpc = 0.0;
+              }
             },
             Kokkos::Sum<int>(block_sum));
         Kokkos::single(Kokkos::PerTeam(member), [&]() { nparticles(b) = block_sum; });

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -95,7 +95,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
                         (num_cells * md->GetMeshPointer()->nbtotal));
 
   // adjust particle number per cell up if threshold temperature is used
-  if (emit_temp_th > 0.0) {
+  if (emit_temp_th > 0.0 && ST == SourceType::emission) {
     // count the number of cells above the temperature threshold
     Real ncell_abv_th = 0.0;
     global_sum_reduce(
@@ -193,7 +193,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
               // NOTE(PDM): We hardcode snpc and sewpc below, but we could imagine
               // introducing supplementary functions/tasks that set these, or even
               // giving downstream codes the opportunity to set these themselves...
-              if (temp > emit_temp_th) {
+              if (temp > emit_temp_th || ST == SourceType::thermal) {
                 snpc = npc;
                 dnum = std::max(std::round((snpc > actnum) * (snpc - actnum)), dnpc_min);
                 sewpc = erad / dnum;
@@ -338,23 +338,11 @@ template TaskStatus
 SourcePhotons<MeshBlockData<Real>, SourceType::thermal, FrequencyType::gray>(
     MeshBlockData<Real> *md, const Real t0, const Real dt);
 template TaskStatus
-SourcePhotons<MeshBlockData<Real>, SourceType::emission, FrequencyType::gray>(
-    MeshBlockData<Real> *md, const Real t0, const Real dt);
-template TaskStatus
-SourcePhotons<MeshData<Real>, SourceType::thermal, FrequencyType::gray>(
-    MeshData<Real> *md, const Real t0, const Real dt);
-template TaskStatus
 SourcePhotons<MeshData<Real>, SourceType::emission, FrequencyType::gray>(
     MeshData<Real> *md, const Real t0, const Real dt);
 template TaskStatus
 SourcePhotons<MeshBlockData<Real>, SourceType::thermal, FrequencyType::multigroup>(
     MeshBlockData<Real> *md, const Real t0, const Real dt);
-template TaskStatus
-SourcePhotons<MeshBlockData<Real>, SourceType::emission, FrequencyType::multigroup>(
-    MeshBlockData<Real> *md, const Real t0, const Real dt);
-template TaskStatus
-SourcePhotons<MeshData<Real>, SourceType::thermal, FrequencyType::multigroup>(
-    MeshData<Real> *md, const Real t0, const Real dt);
 template TaskStatus
 SourcePhotons<MeshData<Real>, SourceType::emission, FrequencyType::multigroup>(
     MeshData<Real> *md, const Real t0, const Real dt);

--- a/src/jaybenne/sourcing.cpp
+++ b/src/jaybenne/sourcing.cpp
@@ -108,7 +108,7 @@ TaskStatus SourcePhotons(T *md, const Real t_start, const Real dt) {
           const Real temp = eos.TemperatureFromDensityInternalEnergy(rho, sie);
           totth += (temp > emit_temp_th ? 1.0 : 0.0);
         },
-        ncell_abv_th);
+        ncell_abv_th, true);
 
     PARTHENON_REQUIRE(ncell_abv_th > 0.0,
                       "emission source but all cells below threshold temperature!");


### PR DESCRIPTION
## Background

* Low / floor temperature regions may not need to source particles, depending on problem.
* Disabling sourcing in floored cells permits reallocating the user's target number of particles into cells above the temperature threshold, potentially improving statistics in those cells.

## Description of Changes

+ Add emit_temp_threshold input parameter.
+ Perform global reduction on total count of cells above threshold.
+ Use emitting cell count to adjust number per emitting cell up.
+ Set source numbers and energy weight to 0 for non-emitting cells.

## Checklist

- [ ] New features are documented
- [ ] Tests added for bug fixes and new features
- [ ] (@lanl.gov employees) Update copyright on changed files

